### PR TITLE
[#44] 배송 서비스 인증 기능 추가

### DIFF
--- a/delivery/Dockerfile
+++ b/delivery/Dockerfile
@@ -1,0 +1,31 @@
+### Build Statge ###
+FROM gradle:8.9-jdk17 AS build
+
+WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+COPY common/ common/
+
+COPY delivery/ delivery/
+
+RUN gradle clean :delivery:bootJar -x test --no-daemon
+
+### Runtime Stage ###
+FROM eclipse-temurin:17-jdk-alpine AS runtime
+
+RUN apk update && apk add --no-cache curl
+
+WORKDIR /app
+
+COPY --from=build /app/delivery/build/libs/*.jar app.jar
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:18086/actuator/health || exit 1
+
+EXPOSE 18086
+
+ENTRYPOINT ["java", \
+    "-Xms512m", \
+    "-Xmx1024m", \
+    "-jar", \
+    "app.jar"]

--- a/delivery/docker-compose.local.yml
+++ b/delivery/docker-compose.local.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=1234
       - TZ=Asia/Seoul
     ports:
-      - "5432:5432"
+      - "5436:5436"
     volumes:
       - delivery-postgres-data:/var/lib/postgresql/data
     networks:

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryService.java
@@ -34,14 +34,10 @@ public class DeliveryService {
         UUID companyDeliveryManagerId = UUID.randomUUID();
 
         Delivery delivery = Delivery.create(
-                OrderId.of(command.orderId()),
-                HubId.of(command.sourceHubId()),
-                HubId.of(command.destinationHubId()),
-                RecipientInfo.of(
-                        command.deliveryAddress(),
-                        command.recipientName(),
-                        command.recipientSlackId()
-                ),
+                command.orderId(),
+                command.sourceHubId(),
+                command.destinationHubId(),
+                command.recipientInfo(),
                 DeliveryManagerId.of(companyDeliveryManagerId)
         );
 
@@ -99,14 +95,14 @@ public class DeliveryService {
                 .orElseThrow(() -> new DeliveryApplicationException(DeliveryApplicationErrorCode.NOT_FOUND_DELIVERY));
     }
 
-    private void validateDuplicateOrderId(UUID orderId) {
-        if (deliveryRepository.existsByOrderId(OrderId.of(orderId))) {
+    private void validateDuplicateOrderId(OrderId orderId) {
+        if (deliveryRepository.existsByOrderId(orderId)) {
             throw new DeliveryApplicationException(DeliveryApplicationErrorCode.DUPLICATE_ORDER_ID);
         }
     }
 
-    private void validateHubExists(UUID hubId) {
-        if (!hubClient.existsById(hubId)) {
+    private void validateHubExists(HubId hubId) {
+        if (!hubClient.existsById(hubId.getId())) {
             throw new DeliveryApplicationException(DeliveryApplicationErrorCode.NON_EXISTENT_HUB);
         }
     }

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryService.java
@@ -64,11 +64,7 @@ public class DeliveryService {
     public DeliveryResult updateRecipientInfo(UUID deliveryId, UpdateDeliveryRecipientInfoCommand command) {
         Delivery delivery = getDeliveryById(deliveryId);
 
-        delivery.updateRecipientInfo(RecipientInfo.of(
-                command.deliveryAddress(),
-                command.recipientName(),
-                command.recipientSlackId()
-        ));
+        delivery.updateRecipientInfo(command.recipientInfo());
 
         return DeliveryResult.from(delivery);
     }

--- a/delivery/src/main/java/com/nowayback/delivery/application/command/CreateDeliveryCommand.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/command/CreateDeliveryCommand.java
@@ -1,26 +1,31 @@
 package com.nowayback.delivery.application.command;
 
-import com.nowayback.delivery.presentation.dto.request.CreateDeliveryRequest;
+import com.nowayback.delivery.domain.delivery.vo.HubId;
+import com.nowayback.delivery.domain.delivery.vo.OrderId;
+import com.nowayback.delivery.domain.delivery.vo.RecipientInfo;
 
 import java.util.UUID;
 
 public record CreateDeliveryCommand (
-        UUID orderId,
-        UUID sourceHubId,
-        UUID destinationHubId,
-        String deliveryAddress,
-        String recipientName,
-        String recipientSlackId
+        OrderId orderId,
+        HubId sourceHubId,
+        HubId destinationHubId,
+        RecipientInfo recipientInfo
 ) {
 
-    public static CreateDeliveryCommand from(CreateDeliveryRequest request) {
+    public static CreateDeliveryCommand of(
+            UUID orderId,
+            UUID sourceHubId,
+            UUID destinationHubId,
+            String deliveryAddress,
+            String recipientName,
+            String recipientSlackId
+    ) {
         return new CreateDeliveryCommand(
-                request.orderId(),
-                request.sourceHubId(),
-                request.destinationHubId(),
-                request.deliveryAddress(),
-                request.recipientName(),
-                request.recipientSlackId()
+                OrderId.of(orderId),
+                HubId.of(sourceHubId),
+                HubId.of(destinationHubId),
+                RecipientInfo.of(deliveryAddress, recipientName, recipientSlackId)
         );
     }
 }

--- a/delivery/src/main/java/com/nowayback/delivery/application/command/UpdateDeliveryRecipientInfoCommand.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/command/UpdateDeliveryRecipientInfoCommand.java
@@ -1,18 +1,18 @@
 package com.nowayback.delivery.application.command;
 
-import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryRecipientInfoRequest;
+import com.nowayback.delivery.domain.delivery.vo.RecipientInfo;
 
 public record UpdateDeliveryRecipientInfoCommand (
-        String deliveryAddress,
-        String recipientName,
-        String recipientSlackId
+        RecipientInfo recipientInfo
 ) {
 
-    public static UpdateDeliveryRecipientInfoCommand from(UpdateDeliveryRecipientInfoRequest request) {
+    public static UpdateDeliveryRecipientInfoCommand of(
+            String deliveryAddress,
+            String recipientName,
+            String recipientSlackId
+    ) {
         return new UpdateDeliveryRecipientInfoCommand(
-                request.deliveryAddress(),
-                request.recipientName(),
-                request.recipientSlackId()
+                RecipientInfo.of(deliveryAddress, recipientName, recipientSlackId)
         );
     }
 }

--- a/delivery/src/main/java/com/nowayback/delivery/application/command/UpdateDeliveryStatusCommand.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/command/UpdateDeliveryStatusCommand.java
@@ -1,13 +1,14 @@
 package com.nowayback.delivery.application.command;
 
 import com.nowayback.delivery.domain.delivery.vo.DeliveryStatus;
-import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryStatusRequest;
 
 public record UpdateDeliveryStatusCommand (
         DeliveryStatus status
 ) {
 
-    public static UpdateDeliveryStatusCommand from(UpdateDeliveryStatusRequest request) {
-        return new UpdateDeliveryStatusCommand(request.status());
+    public static UpdateDeliveryStatusCommand of(
+            DeliveryStatus status
+    ) {
+        return new UpdateDeliveryStatusCommand(status);
     }
 }

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -54,13 +54,15 @@ public class DeliveryController {
     }
 
     @GetMapping
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER, UserRole.COMPANY_MANAGER})
     public ResponseEntity<Page<DeliveryResponse>> searchDeliveries(
             @RequestParam(required = false) UUID orderId,
             @RequestParam(required = false) UUID sourceHubId,
             @RequestParam(required = false) UUID destinationHubId,
             @RequestParam(required = false) DeliveryStatus status,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @CurrentUser AuthUser authUser
     ) {
         Page<DeliveryResponse> responses = deliveryService.searchDeliveries(orderId, sourceHubId, destinationHubId, status, page, size)
                 .map(DeliveryResponse::from);

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -98,7 +98,7 @@ public class DeliveryController {
             @PathVariable UUID deliveryId,
             @Valid @RequestBody UpdateDeliveryStatusRequest request
     ) {
-        UpdateDeliveryStatusCommand command = UpdateDeliveryStatusCommand.from(request);
+        UpdateDeliveryStatusCommand command = UpdateDeliveryStatusCommand.of(request.status());
 
         return ResponseEntity.ok(
                 DeliveryResponse.from(deliveryService.updateDeliveryStatus(deliveryId, command))

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -43,8 +43,10 @@ public class DeliveryController {
     }
 
     @GetMapping("/{deliveryId}")
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER, UserRole.COMPANY_MANAGER})
     public ResponseEntity<DeliveryResponse> getDelivery(
-            @PathVariable UUID deliveryId
+            @PathVariable UUID deliveryId,
+            @CurrentUser AuthUser authUser
     ) {
         return ResponseEntity.ok(
                 DeliveryResponse.from(deliveryService.getDelivery(deliveryId))

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -32,8 +32,7 @@ public class DeliveryController {
     @PostMapping
     @RequireRole(UserRole.MASTER)
     public ResponseEntity<DeliveryResponse> createDelivery(
-            @Valid @RequestBody CreateDeliveryRequest request,
-            @CurrentUser AuthUser authUser
+            @Valid @RequestBody CreateDeliveryRequest request
     ) {
         CreateDeliveryCommand command = CreateDeliveryCommand.from(request);
 
@@ -45,8 +44,8 @@ public class DeliveryController {
     @GetMapping("/{deliveryId}")
     @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER, UserRole.COMPANY_MANAGER})
     public ResponseEntity<DeliveryResponse> getDelivery(
-            @PathVariable UUID deliveryId,
-            @CurrentUser AuthUser authUser
+            @CurrentUser AuthUser authUser,
+            @PathVariable UUID deliveryId
     ) {
         return ResponseEntity.ok(
                 DeliveryResponse.from(deliveryService.getDelivery(deliveryId))
@@ -56,13 +55,13 @@ public class DeliveryController {
     @GetMapping
     @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER, UserRole.COMPANY_MANAGER})
     public ResponseEntity<Page<DeliveryResponse>> searchDeliveries(
+            @CurrentUser AuthUser authUser,
             @RequestParam(required = false) UUID orderId,
             @RequestParam(required = false) UUID sourceHubId,
             @RequestParam(required = false) UUID destinationHubId,
             @RequestParam(required = false) DeliveryStatus status,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @CurrentUser AuthUser authUser
+            @RequestParam(defaultValue = "10") int size
     ) {
         Page<DeliveryResponse> responses = deliveryService.searchDeliveries(orderId, sourceHubId, destinationHubId, status, page, size)
                 .map(DeliveryResponse::from);
@@ -73,9 +72,9 @@ public class DeliveryController {
     @PatchMapping("/{deliveryId}")
     @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER})
     public ResponseEntity<DeliveryResponse> updateDelivery(
+            @CurrentUser AuthUser authUser,
             @PathVariable UUID deliveryId,
-            @Valid @RequestBody UpdateDeliveryRecipientInfoRequest request,
-            @CurrentUser AuthUser authUser
+            @Valid @RequestBody UpdateDeliveryRecipientInfoRequest request
     ) {
         UpdateDeliveryRecipientInfoCommand command = UpdateDeliveryRecipientInfoCommand.from(request);
 
@@ -87,9 +86,9 @@ public class DeliveryController {
     @PatchMapping("/{deliveryId}/status")
     @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER})
     public ResponseEntity<DeliveryResponse> updateDeliveryStatus(
+            @CurrentUser AuthUser authUser,
             @PathVariable UUID deliveryId,
-            @Valid @RequestBody UpdateDeliveryStatusRequest request,
-            @CurrentUser AuthUser authUser
+            @Valid @RequestBody UpdateDeliveryStatusRequest request
     ) {
         UpdateDeliveryStatusCommand command = UpdateDeliveryStatusCommand.from(request);
 
@@ -101,8 +100,8 @@ public class DeliveryController {
     @DeleteMapping("/{deliveryId}")
     @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER})
     public ResponseEntity<Void> deleteDelivery(
-            @PathVariable UUID deliveryId,
-            @CurrentUser AuthUser authUser
+            @CurrentUser AuthUser authUser,
+            @PathVariable UUID deliveryId
     ) {
         deliveryService.deleteDelivery(deliveryId);
 

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -1,5 +1,9 @@
 package com.nowayback.delivery.presentation;
 
+import com.nowayback.common.security.annotation.AuthUser;
+import com.nowayback.common.security.annotation.CurrentUser;
+import com.nowayback.common.security.annotation.RequireRole;
+import com.nowayback.common.security.annotation.UserRole;
 import com.nowayback.delivery.application.DeliveryService;
 import com.nowayback.delivery.application.command.CreateDeliveryCommand;
 import com.nowayback.delivery.application.command.UpdateDeliveryRecipientInfoCommand;
@@ -26,8 +30,10 @@ public class DeliveryController {
     private final DeliveryService deliveryService;
 
     @PostMapping
+    @RequireRole(UserRole.MASTER)
     public ResponseEntity<DeliveryResponse> createDelivery(
-            @Valid @RequestBody CreateDeliveryRequest request
+            @Valid @RequestBody CreateDeliveryRequest request,
+            @CurrentUser AuthUser authUser
     ) {
         CreateDeliveryCommand command = CreateDeliveryCommand.from(request);
 

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -84,7 +84,11 @@ public class DeliveryController {
             @PathVariable UUID deliveryId,
             @Valid @RequestBody UpdateDeliveryRecipientInfoRequest request
     ) {
-        UpdateDeliveryRecipientInfoCommand command = UpdateDeliveryRecipientInfoCommand.from(request);
+        UpdateDeliveryRecipientInfoCommand command = UpdateDeliveryRecipientInfoCommand.of(
+                request.deliveryAddress(),
+                request.recipientName(),
+                request.recipientSlackId()
+        );
 
         return ResponseEntity.ok(
                 DeliveryResponse.from(deliveryService.updateRecipientInfo(deliveryId, command))

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -85,9 +85,11 @@ public class DeliveryController {
     }
 
     @PatchMapping("/{deliveryId}/status")
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER})
     public ResponseEntity<DeliveryResponse> updateDeliveryStatus(
             @PathVariable UUID deliveryId,
-            @Valid @RequestBody UpdateDeliveryStatusRequest request
+            @Valid @RequestBody UpdateDeliveryStatusRequest request,
+            @CurrentUser AuthUser authUser
     ) {
         UpdateDeliveryStatusCommand command = UpdateDeliveryStatusCommand.from(request);
 

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -1,5 +1,6 @@
 package com.nowayback.delivery.presentation;
 
+import com.nowayback.common.dto.PageResponse;
 import com.nowayback.common.security.annotation.AuthUser;
 import com.nowayback.common.security.annotation.CurrentUser;
 import com.nowayback.common.security.annotation.RequireRole;
@@ -54,7 +55,7 @@ public class DeliveryController {
 
     @GetMapping
     @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER, UserRole.COMPANY_MANAGER})
-    public ResponseEntity<Page<DeliveryResponse>> searchDeliveries(
+    public ResponseEntity<PageResponse<DeliveryResponse>> searchDeliveries(
             @CurrentUser AuthUser authUser,
             @RequestParam(required = false) UUID orderId,
             @RequestParam(required = false) UUID sourceHubId,
@@ -66,7 +67,7 @@ public class DeliveryController {
         Page<DeliveryResponse> responses = deliveryService.searchDeliveries(orderId, sourceHubId, destinationHubId, status, page, size)
                 .map(DeliveryResponse::from);
 
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(PageResponse.fromPage(responses));
     }
 
     @PatchMapping("/{deliveryId}")

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -35,7 +35,14 @@ public class DeliveryController {
     public ResponseEntity<DeliveryResponse> createDelivery(
             @Valid @RequestBody CreateDeliveryRequest request
     ) {
-        CreateDeliveryCommand command = CreateDeliveryCommand.from(request);
+        CreateDeliveryCommand command = CreateDeliveryCommand.of(
+                request.orderId(),
+                request.sourceHubId(),
+                request.destinationHubId(),
+                request.deliveryAddress(),
+                request.recipientName(),
+                request.recipientSlackId()
+        );
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -99,8 +99,10 @@ public class DeliveryController {
     }
 
     @DeleteMapping("/{deliveryId}")
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER})
     public ResponseEntity<Void> deleteDelivery(
-            @PathVariable UUID deliveryId
+            @PathVariable UUID deliveryId,
+            @CurrentUser AuthUser authUser
     ) {
         deliveryService.deleteDelivery(deliveryId);
 

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryController.java
@@ -71,9 +71,11 @@ public class DeliveryController {
     }
 
     @PatchMapping("/{deliveryId}")
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER})
     public ResponseEntity<DeliveryResponse> updateDelivery(
             @PathVariable UUID deliveryId,
-            @Valid @RequestBody UpdateDeliveryRecipientInfoRequest request
+            @Valid @RequestBody UpdateDeliveryRecipientInfoRequest request,
+            @CurrentUser AuthUser authUser
     ) {
         UpdateDeliveryRecipientInfoCommand command = UpdateDeliveryRecipientInfoCommand.from(request);
 

--- a/delivery/src/test/java/com/nowayback/delivery/application/DeliveryServiceTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/application/DeliveryServiceTest.java
@@ -49,8 +49,8 @@ class DeliveryServiceTest {
             CreateDeliveryCommand command = CREATE_DELIVERY_COMMAND;
             Delivery delivery = createDelivery();
 
-            UUID sourceHubId = command.sourceHubId();
-            UUID destinationHubId = command.destinationHubId();
+            UUID sourceHubId = command.sourceHubId().getId();
+            UUID destinationHubId = command.destinationHubId().getId();
 
             when(deliveryRepository.existsByOrderId(any(OrderId.class))).thenReturn(false);
             when(hubClient.existsById(sourceHubId)).thenReturn(true);
@@ -94,7 +94,7 @@ class DeliveryServiceTest {
         void createDelivery_WithNonExistentSourceHubId_throwsException() {
             /* given */
             CreateDeliveryCommand command = CREATE_DELIVERY_COMMAND;
-            UUID sourceHubId = command.sourceHubId();
+            UUID sourceHubId = command.sourceHubId().getId();
 
             when(deliveryRepository.existsByOrderId(any(OrderId.class))).thenReturn(false);
             when(hubClient.existsById(sourceHubId)).thenReturn(false);
@@ -112,8 +112,8 @@ class DeliveryServiceTest {
         void createDelivery_WithNonExistentDestinationHubId_throwsException() {
             /* given */
             CreateDeliveryCommand command = CREATE_DELIVERY_COMMAND;
-            UUID sourceHubId = command.sourceHubId();
-            UUID destinationHubId = command.destinationHubId();
+            UUID sourceHubId = command.sourceHubId().getId();
+            UUID destinationHubId = command.destinationHubId().getId();
 
             when(deliveryRepository.existsByOrderId(any(OrderId.class))).thenReturn(false);
             when(hubClient.existsById(sourceHubId)).thenReturn(true);

--- a/delivery/src/test/java/com/nowayback/delivery/domain/delivery/entity/DeliveryTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/domain/delivery/entity/DeliveryTest.java
@@ -1,6 +1,5 @@
-package com.nowayback.delivery.domain.entity;
+package com.nowayback.delivery.domain.delivery.entity;
 
-import com.nowayback.delivery.domain.delivery.entity.Delivery;
 import com.nowayback.delivery.domain.delivery.vo.*;
 import com.nowayback.delivery.domain.exception.DeliveryDomainException;
 import org.junit.jupiter.api.DisplayName;

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryFixture.java
@@ -94,7 +94,7 @@ public class DeliveryFixture {
             RECIPIENT_SLACK_ID
     );
 
-    public static final UpdateDeliveryRecipientInfoCommand UPDATE_DELIVERY_RECIPIENT_INFO_COMMAND = new UpdateDeliveryRecipientInfoCommand(
+    public static final UpdateDeliveryRecipientInfoCommand UPDATE_DELIVERY_RECIPIENT_INFO_COMMAND = UpdateDeliveryRecipientInfoCommand.of(
             DELIVERY_ADDRESS,
             MODIFIED_DELIVERY_NAME,
             MODIFIED_DELIVERY_SLACK_ID

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryFixture.java
@@ -85,7 +85,7 @@ public class DeliveryFixture {
     );
 
     /* delivery command */
-    public static final CreateDeliveryCommand CREATE_DELIVERY_COMMAND = new CreateDeliveryCommand(
+    public static final CreateDeliveryCommand CREATE_DELIVERY_COMMAND = CreateDeliveryCommand.of(
             ORDER_UUID,
             SOURCE_HUB_UUID,
             DESTINATION_HUB_UUID,

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/ControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/ControllerTest.java
@@ -32,4 +32,8 @@ public abstract class ControllerTest {
                         .header(JwtConstants.HEADER_ROLE, role.name())
         );
     }
+
+    protected ResultActions performWithAuth(MockHttpServletRequestBuilder builder) throws Exception {
+        return performWithAuth(builder, UserRole.MASTER);
+    }
 }

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/ControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/ControllerTest.java
@@ -1,0 +1,35 @@
+package com.nowayback.delivery.presentation;
+
+import com.nowayback.common.exception.GlobalExceptionHandler;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.common.security.config.CommonWebConfig;
+import com.nowayback.common.security.interceptor.JwtConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.UUID;
+
+@Import({
+        CommonWebConfig.class,
+        GlobalExceptionHandler.class
+})
+public abstract class ControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    protected ResultActions performWithAuth(MockHttpServletRequestBuilder builder, UserRole role) throws Exception {
+        UUID userId = UUID.randomUUID();
+        String username = "test";
+
+        return mockMvc.perform(
+                builder
+                        .header(JwtConstants.HEADER_USER_ID, userId.toString())
+                        .header(JwtConstants.HEADER_USERNAME, username)
+                        .header(JwtConstants.HEADER_ROLE, role.name())
+        );
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nowayback.common.security.annotation.UserRole;
 import com.nowayback.delivery.application.DeliveryService;
 import com.nowayback.delivery.application.dto.DeliveryResult;
+import com.nowayback.delivery.application.exception.DeliveryApplicationException;
 import com.nowayback.delivery.domain.delivery.vo.DeliveryStatus;
 import com.nowayback.delivery.presentation.dto.request.CreateDeliveryRequest;
 import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryRecipientInfoRequest;
@@ -110,9 +111,10 @@ class DeliveryControllerTest extends ControllerTest {
     @DisplayName("배송 단일 조회 API")
     class GetDelivery {
 
-        @Test
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER", "DELIVERY_MANAGER", "COMPANY_MANAGER"})
         @DisplayName("유효한 요청이 들어오면 배송을 조회한다.")
-        void getDelivery_ExistingUuid_Success() throws Exception {
+        void getDelivery_ExistingUuid_Success(UserRole role) throws Exception {
             /* given */
             DeliveryResult result = DELIVERY_RESULT;
 
@@ -120,9 +122,19 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            performWithAuth(get(BASE_URL + "/" + DELIVERY_UUID), UserRole.MASTER)
+            performWithAuth(get(BASE_URL + "/" + DELIVERY_UUID), role)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.orderId").value(result.orderId().toString()));
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void getDelivery_Unauthorized_WhenHeaderMissing() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(get(BASE_URL + "/" + DELIVERY_UUID))
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -157,8 +157,7 @@ class DeliveryControllerTest extends ControllerTest {
                             .param("destinationHubId", DESTINATION_HUB_UUID.toString())
                             .param("status", DeliveryStatus.WAITING_AT_HUB.name())
                             .param("page", String.valueOf(PAGE))
-                            .param("size",  String.valueOf(SIZE)),
-                    UserRole.MASTER)
+                            .param("size",  String.valueOf(SIZE)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.content.length()").value(2))
                     .andExpect(jsonPath("$.totalElements").value(2));
@@ -215,8 +214,7 @@ class DeliveryControllerTest extends ControllerTest {
             /* then */
             performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)),
-                    UserRole.MASTER)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest());
         }
 
@@ -281,8 +279,7 @@ class DeliveryControllerTest extends ControllerTest {
             /* then */
             performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID + "/status")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)),
-                    UserRole.MASTER)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest());
         }
 

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -1,6 +1,7 @@
 package com.nowayback.delivery.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nowayback.common.security.annotation.UserRole;
 import com.nowayback.delivery.application.DeliveryService;
 import com.nowayback.delivery.application.dto.DeliveryResult;
 import com.nowayback.delivery.domain.delivery.vo.DeliveryStatus;
@@ -14,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 import static com.nowayback.delivery.fixture.DeliveryFixture.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -26,9 +26,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(DeliveryController.class)
 class DeliveryControllerTest extends ControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
 
     @MockitoBean
     private DeliveryService deliveryService;
@@ -53,9 +50,10 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            mockMvc.perform(post(BASE_URL)
+            performWithAuth(post(BASE_URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.MASTER)
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.status").value(DeliveryStatus.WAITING_AT_HUB.name()));
         }
@@ -68,9 +66,10 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            mockMvc.perform(post(BASE_URL)
+            performWithAuth(post(BASE_URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.MASTER)
                     .andExpect(status().isBadRequest());
         }
     }
@@ -89,7 +88,7 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            mockMvc.perform(get(BASE_URL + "/" + DELIVERY_UUID))
+            performWithAuth(get(BASE_URL + "/" + DELIVERY_UUID), UserRole.MASTER)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.orderId").value(result.orderId().toString()));
         }
@@ -107,13 +106,14 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            mockMvc.perform(get(BASE_URL)
+            performWithAuth(get(BASE_URL)
                             .param("orderId", ORDER_UUID.toString())
                             .param("sourceHubId", SOURCE_HUB_UUID.toString())
                             .param("destinationHubId", DESTINATION_HUB_UUID.toString())
                             .param("status", DeliveryStatus.WAITING_AT_HUB.name())
                             .param("page", String.valueOf(PAGE))
-                            .param("size",  String.valueOf(SIZE)))
+                            .param("size",  String.valueOf(SIZE)),
+                    UserRole.MASTER)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.content.length()").value(2))
                     .andExpect(jsonPath("$.totalElements").value(2));
@@ -135,9 +135,10 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            mockMvc.perform(patch(BASE_URL + "/" + DELIVERY_UUID)
+            performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.MASTER)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.recipientName").value(request.recipientName()));
         }
@@ -150,9 +151,10 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            mockMvc.perform(patch(BASE_URL + "/" + DELIVERY_UUID)
+            performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.MASTER)
                     .andExpect(status().isBadRequest());
         }
     }
@@ -172,9 +174,10 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            mockMvc.perform(patch(BASE_URL + "/" + DELIVERY_UUID + "/status")
+            performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID + "/status")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.MASTER)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value(DeliveryStatus.TRANSIT_BETWEEN_HUBS.name()));
         }
@@ -187,9 +190,10 @@ class DeliveryControllerTest extends ControllerTest {
 
             /* when */
             /* then */
-            mockMvc.perform(patch(BASE_URL + "/" + DELIVERY_UUID + "/status")
+            performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID + "/status")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.MASTER)
                     .andExpect(status().isBadRequest());
         }
     }
@@ -204,7 +208,7 @@ class DeliveryControllerTest extends ControllerTest {
             /* given */
             /* when */
             /* then */
-            mockMvc.perform(delete(BASE_URL + "/" + DELIVERY_UUID))
+            performWithAuth(delete(BASE_URL + "/" + DELIVERY_UUID), UserRole.MASTER)
                     .andExpect(status().isNoContent());
         }
     }

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -185,9 +185,10 @@ class DeliveryControllerTest extends ControllerTest {
     @DisplayName("배송 수령인 정보 수정 API")
     class UpdateDeliveryRecipientInfo {
 
-        @Test
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER", "DELIVERY_MANAGER"})
         @DisplayName("유효한 요청이 들어오면 배송 수령인 정보를 수정한다.")
-        void updateDeliveryRecipientInfo_ValidRequest_Success() throws Exception {
+        void updateDeliveryRecipientInfo_ValidRequest_Success(UserRole role) throws Exception {
             /* given */
             UpdateDeliveryRecipientInfoRequest request = VALID_UPDATE_DELIVERY_RECIPIENT_INFO_REQUEST;
             DeliveryResult result = MODIFIED_DELIVERY_RESULT;
@@ -199,7 +200,7 @@ class DeliveryControllerTest extends ControllerTest {
             performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)),
-                    UserRole.MASTER)
+                    role)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.recipientName").value(request.recipientName()));
         }
@@ -217,6 +218,32 @@ class DeliveryControllerTest extends ControllerTest {
                             .content(objectMapper.writeValueAsString(request)),
                     UserRole.MASTER)
                     .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void updateDeliveryRecipientInfo_Unauthorized_WhenHeaderMissing() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(patch(BASE_URL + "/" + DELIVERY_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(VALID_UPDATE_DELIVERY_RECIPIENT_INFO_REQUEST)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void updateDeliveryRecipientInfo_Forbidden_WhenRoleInvalid(UserRole role) throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(VALID_UPDATE_DELIVERY_RECIPIENT_INFO_REQUEST)),
+                    role)
+                    .andExpect(status().isForbidden());
         }
     }
 

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -78,7 +78,7 @@ class DeliveryControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
-        void createDelivery_Unauthorized_WhenHeaderMissing() throws Exception {
+        void createDelivery_WhenHeaderMissing_Unauthorized() throws Exception {
             /* given */
             CreateDeliveryRequest request = VALID_CREATE_DELIVERY_REQUEST;
 
@@ -93,7 +93,7 @@ class DeliveryControllerTest extends ControllerTest {
         @ParameterizedTest
         @EnumSource(value = UserRole.class, names = {"HUB_MANAGER", "DELIVERY_MANAGER", "COMPANY_MANAGER"})
         @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
-        void createDelivery_Forbidden_WhenRoleInvalid(UserRole role) throws Exception {
+        void createDelivery_WhenRoleInvalid_Forbidden(UserRole role) throws Exception {
             /* given */
             CreateDeliveryRequest request = VALID_CREATE_DELIVERY_REQUEST;
 
@@ -129,7 +129,7 @@ class DeliveryControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
-        void getDelivery_Unauthorized_WhenHeaderMissing() throws Exception {
+        void getDelivery_WhenHeaderMissing_Unauthorized() throws Exception {
             /* given */
             /* when */
             /* then */
@@ -166,7 +166,7 @@ class DeliveryControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
-        void searchDeliveries_Unauthorized_WhenHeaderMissing() throws Exception {
+        void searchDeliveries_WhenHeaderMissing_Unauthorized() throws Exception {
             /* given */
             /* when */
             /* then */
@@ -222,7 +222,7 @@ class DeliveryControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
-        void updateDeliveryRecipientInfo_Unauthorized_WhenHeaderMissing() throws Exception {
+        void updateDeliveryRecipientInfo_WhenHeaderMissing_Unauthorized() throws Exception {
             /* given */
             /* when */
             /* then */
@@ -235,7 +235,7 @@ class DeliveryControllerTest extends ControllerTest {
         @ParameterizedTest
         @EnumSource(value = UserRole.class, names = {"COMPANY_MANAGER"})
         @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
-        void updateDeliveryRecipientInfo_Forbidden_WhenRoleInvalid(UserRole role) throws Exception {
+        void updateDeliveryRecipientInfo_WhenRoleInvalid_Forbidden(UserRole role) throws Exception {
             /* given */
             /* when */
             /* then */
@@ -288,7 +288,7 @@ class DeliveryControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
-        void updateDeliveryStatus_Unauthorized_WhenHeaderMissing() throws Exception {
+        void updateDeliveryStatus_WhenHeaderMissing_Unauthorized() throws Exception {
             /* given */
             /* when */
             /* then */
@@ -301,7 +301,7 @@ class DeliveryControllerTest extends ControllerTest {
         @ParameterizedTest
         @EnumSource(value = UserRole.class, names = {"COMPANY_MANAGER"})
         @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
-        void updateDeliveryStatus_Forbidden_WhenRoleInvalid(UserRole role) throws Exception {
+        void updateDeliveryStatus_WhenRoleInvalid_Forbidden(UserRole role) throws Exception {
             /* given */
             /* when */
             /* then */
@@ -330,7 +330,7 @@ class DeliveryControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
-        void deleteDelivery_Unauthorized_WhenHeaderMissing() throws Exception {
+        void deleteDelivery_WhenHeaderMissing_Unauthorized() throws Exception {
             /* given */
             /* when */
             /* then */
@@ -341,7 +341,7 @@ class DeliveryControllerTest extends ControllerTest {
         @ParameterizedTest
         @EnumSource(value = UserRole.class, names = {"DELIVERY_MANAGER", "COMPANY_MANAGER"})
         @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
-        void deleteDelivery_Forbidden_WhenRoleInvalid(UserRole role) throws Exception {
+        void deleteDelivery_WhenRoleInvalid_Forbidden(UserRole role) throws Exception {
             /* given */
             /* when */
             /* then */

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -251,9 +251,10 @@ class DeliveryControllerTest extends ControllerTest {
     @DisplayName("배송 상태 수정 API")
     class UpdateDeliveryStatus {
 
-        @Test
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER", "DELIVERY_MANAGER"})
         @DisplayName("배송 상태 수정 요청이 들어오면 배송 상태를 수정한다.")
-        void updateDeliveryStatus_ValidRequest_Success() throws Exception {
+        void updateDeliveryStatus_ValidRequest_Success(UserRole role) throws Exception {
             /* given */
             UpdateDeliveryStatusRequest request = VALID_UPDATE_DELIVERY_STATUS_REQUEST;
             DeliveryResult result = DELIVERY_RESULT_TRANSIT_BETWEEN_HUBS;
@@ -265,7 +266,7 @@ class DeliveryControllerTest extends ControllerTest {
             performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID + "/status")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)),
-                    UserRole.MASTER)
+                    role)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value(DeliveryStatus.TRANSIT_BETWEEN_HUBS.name()));
         }
@@ -283,6 +284,32 @@ class DeliveryControllerTest extends ControllerTest {
                             .content(objectMapper.writeValueAsString(request)),
                     UserRole.MASTER)
                     .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void updateDeliveryStatus_Unauthorized_WhenHeaderMissing() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(patch(BASE_URL + "/" + DELIVERY_UUID + "/status")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(VALID_UPDATE_DELIVERY_STATUS_REQUEST)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void updateDeliveryStatus_Forbidden_WhenRoleInvalid(UserRole role) throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/" + DELIVERY_UUID + "/status")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(VALID_UPDATE_DELIVERY_STATUS_REQUEST)),
+                    role)
+                    .andExpect(status().isForbidden());
         }
     }
 

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -142,9 +142,10 @@ class DeliveryControllerTest extends ControllerTest {
     @DisplayName("배송 검색 API")
     class SearchDeliveries {
 
-        @Test
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER", "DELIVERY_MANAGER", "COMPANY_MANAGER"})
         @DisplayName("유효한 요청이 들어오면 배송 목록을 조회한다.")
-        void searchDeliveries_ValidRequest_Success() throws Exception {
+        void searchDeliveries_ValidRequest_Success(UserRole role) throws Exception {
             /* given */
             given(deliveryService.searchDeliveries(any(), any(), any(), any(), anyInt(), anyInt())).willReturn(DELIVERY_RESULT_PAGE);
 
@@ -161,6 +162,22 @@ class DeliveryControllerTest extends ControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.content.length()").value(2))
                     .andExpect(jsonPath("$.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void searchDeliveries_Unauthorized_WhenHeaderMissing() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(get(BASE_URL)
+                            .param("orderId", ORDER_UUID.toString())
+                            .param("sourceHubId", SOURCE_HUB_UUID.toString())
+                            .param("destinationHubId", DESTINATION_HUB_UUID.toString())
+                            .param("status", DeliveryStatus.WAITING_AT_HUB.name())
+                            .param("page", String.valueOf(PAGE))
+                            .param("size",  String.valueOf(SIZE)))
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -317,14 +317,36 @@ class DeliveryControllerTest extends ControllerTest {
     @DisplayName("배송 삭제 API")
     class DeleteDelivery {
 
-        @Test
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER"})
         @DisplayName("배송 삭제 요청이 들어오면 배송을 삭제한다.")
-        void deleteDelivery_ValidRequest_Success() throws Exception {
+        void deleteDelivery_ValidRequest_Success(UserRole role) throws Exception {
             /* given */
             /* when */
             /* then */
-            performWithAuth(delete(BASE_URL + "/" + DELIVERY_UUID), UserRole.MASTER)
+            performWithAuth(delete(BASE_URL + "/" + DELIVERY_UUID), role)
                     .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void deleteDelivery_Unauthorized_WhenHeaderMissing() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(delete(BASE_URL + "/" + DELIVERY_UUID))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void deleteDelivery_Forbidden_WhenRoleInvalid(UserRole role) throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            performWithAuth(delete(BASE_URL + "/" + DELIVERY_UUID), role)
+                    .andExpect(status().isForbidden());
         }
     }
 }

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -11,6 +11,8 @@ import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryStatusReque
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -39,9 +41,10 @@ class DeliveryControllerTest extends ControllerTest {
     @DisplayName("배송 생성 API")
     class CreateDelivery {
 
-        @Test
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER"})
         @DisplayName("유효한 요청이 들어오면 배송이 생성된다.")
-        void createDelivery_ValidRequest_Success() throws Exception {
+        void createDelivery_ValidRequest_Success(UserRole role) throws Exception {
             /* given */
             CreateDeliveryRequest request = VALID_CREATE_DELIVERY_REQUEST;
             DeliveryResult result = DELIVERY_RESULT;
@@ -53,7 +56,7 @@ class DeliveryControllerTest extends ControllerTest {
             performWithAuth(post(BASE_URL)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)),
-                    UserRole.MASTER)
+                    role)
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.status").value(DeliveryStatus.WAITING_AT_HUB.name()));
         }
@@ -68,8 +71,7 @@ class DeliveryControllerTest extends ControllerTest {
             /* then */
             performWithAuth(post(BASE_URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)),
-                    UserRole.MASTER)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest());
         }
 
@@ -87,9 +89,10 @@ class DeliveryControllerTest extends ControllerTest {
                     .andExpect(status().isUnauthorized());
         }
 
-        @Test
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"HUB_MANAGER", "DELIVERY_MANAGER", "COMPANY_MANAGER"})
         @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
-        void createDelivery_Forbidden_WhenRoleInvalid() throws Exception {
+        void createDelivery_Forbidden_WhenRoleInvalid(UserRole role) throws Exception {
             /* given */
             CreateDeliveryRequest request = VALID_CREATE_DELIVERY_REQUEST;
 
@@ -98,7 +101,7 @@ class DeliveryControllerTest extends ControllerTest {
             performWithAuth(post(BASE_URL)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)),
-                    UserRole.COMPANY_MANAGER)
+                    role)
                     .andExpect(status().isForbidden());
         }
     }

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -159,7 +159,7 @@ class DeliveryControllerTest extends ControllerTest {
                             .param("page", String.valueOf(PAGE))
                             .param("size",  String.valueOf(SIZE)))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.content.length()").value(2))
+                    .andExpect(jsonPath("$.items.length()").value(2))
                     .andExpect(jsonPath("$.totalElements").value(2));
         }
 

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @WebMvcTest(DeliveryController.class)
-class DeliveryControllerTest {
+class DeliveryControllerTest extends ControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryControllerTest.java
@@ -72,6 +72,35 @@ class DeliveryControllerTest extends ControllerTest {
                     UserRole.MASTER)
                     .andExpect(status().isBadRequest());
         }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void createDelivery_Unauthorized_WhenHeaderMissing() throws Exception {
+            /* given */
+            CreateDeliveryRequest request = VALID_CREATE_DELIVERY_REQUEST;
+
+            /* when */
+            /* then */
+            mockMvc.perform(post(BASE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void createDelivery_Forbidden_WhenRoleInvalid() throws Exception {
+            /* given */
+            CreateDeliveryRequest request = VALID_CREATE_DELIVERY_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(post(BASE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.COMPANY_MANAGER)
+                    .andExpect(status().isForbidden());
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #44 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
`DeliveryController`에 인증 정보를 받아오기 위한 `@RequireRole`, `@CurrentUser`를 적용
각 Command의 Request 의존 제거 리팩토링

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
권한에 따른 로직 분리는 `DeliveryRoute`, `DeliveryManager` 구현 후에 수행할 예정입니다.
테스트 코드에서 인증 정보를 받아오기 위한 헤더 주입 로직이 잘 작성되었는지 확인해주세요!
