### PR TITLE
[#49] 배송 경로 도메인 API 구현

### DIFF
--- a/delivery/docker-compose.local.yml
+++ b/delivery/docker-compose.local.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=1234
       - TZ=Asia/Seoul
     ports:
-      - "5436:5436"
+      - "5436:5432"
     volumes:
       - delivery-postgres-data:/var/lib/postgresql/data
     networks:

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryRouteService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryRouteService.java
@@ -101,8 +101,8 @@ public class DeliveryRouteService {
 
     @Transactional
     public void deleteDeliveryRoutesByDeliveryId(UUID userId, UUID deliveryId) {
-        DeliveryRoute deliveryRoute = getDeliveryRouteById(deliveryId);
-        deliveryRoute.delete(userId);
+        List<DeliveryRoute> routes = deliveryRouteRepository.findAllByDeliveryId(DeliveryId.of(deliveryId));
+        routes.forEach(route -> route.delete(userId));
     }
 
     private DeliveryRoute getDeliveryRouteById(UUID deliveryRouteId) {

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryRouteService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryRouteService.java
@@ -1,0 +1,113 @@
+package com.nowayback.delivery.application;
+
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.delivery.application.command.CreateDeliveryRoutesCommand;
+import com.nowayback.delivery.application.command.UpdateDeliveryRouteInfoCommand;
+import com.nowayback.delivery.application.command.UpdateDeliveryRouteStatusCommand;
+import com.nowayback.delivery.application.dto.DeliveryRouteResult;
+import com.nowayback.delivery.application.exception.DeliveryRouteApplicationErrorCode;
+import com.nowayback.delivery.application.exception.DeliveryRouteApplicationException;
+import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
+import com.nowayback.delivery.domain.deliveryroute.repository.DeliveryRouteRepository;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryId;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryManagerId;
+import com.nowayback.delivery.domain.deliveryroute.vo.RouteInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryRouteService {
+
+    private final DeliveryRouteRepository deliveryRouteRepository;
+
+    @Transactional
+    public List<DeliveryRouteResult> createDeliveryRoutes(CreateDeliveryRoutesCommand command) {
+        DeliveryId deliveryId = command.deliveryId();
+
+        List<DeliveryRoute> deliveryRoutes = command.segments().stream()
+                .map(segment -> createDeliveryRoute(deliveryId, segment))
+                .toList();
+
+        List<DeliveryRoute> savedRoutes = deliveryRouteRepository.saveAll(deliveryRoutes);
+
+        return savedRoutes.stream()
+                .map(DeliveryRouteResult::from)
+                .toList();
+    }
+
+    private DeliveryRoute createDeliveryRoute(DeliveryId deliveryId, CreateDeliveryRoutesCommand.DeliveryRouteSegment segment) {
+        // TODO: Delivery Manager 할당 로직 추가 필요
+        DeliveryManagerId deliveryManagerId =DeliveryManagerId.of(UUID.randomUUID());
+
+        RouteInfo routeInfo = RouteInfo.of(
+                segment.expectedDistanceMeters(),
+                segment.expectedDurationMinutes(),
+                null,
+                null
+        );
+
+        return DeliveryRoute.create(
+                deliveryId,
+                segment.sequence(),
+                segment.hubRoute(),
+                deliveryManagerId,
+                routeInfo
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public DeliveryRouteResult getDelivery(UUID userId, UserRole role, UUID deliveryRouteId) {
+        DeliveryRoute deliveryRoute = getDeliveryRouteById(deliveryRouteId);
+        return DeliveryRouteResult.from(deliveryRoute);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<DeliveryRouteResult> searchDeliveryRoutes(UUID userId, UserRole role, UUID deliveryId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<DeliveryRoute> deliveryRoutes = deliveryRouteRepository.findAllByDeliveryId(DeliveryId.of(deliveryId), pageable);
+        return deliveryRoutes.map(DeliveryRouteResult::from);
+    }
+
+    @Transactional
+    public DeliveryRouteResult updateDeliveryRouteStatus(UUID userId, UserRole role, UUID deliveryRouteId, UpdateDeliveryRouteStatusCommand command) {
+        DeliveryRoute deliveryRoute = getDeliveryRouteById(deliveryRouteId);
+
+        deliveryRoute.updateStatus(command.status());
+        return DeliveryRouteResult.from(deliveryRoute);
+    }
+
+    @Transactional
+    public DeliveryRouteResult updateDeliveryRouteInfo(UUID userId, UserRole role, UUID deliveryRouteId, UpdateDeliveryRouteInfoCommand command) {
+        DeliveryRoute deliveryRoute = getDeliveryRouteById(deliveryRouteId);
+        RouteInfo oldRouteInfo = deliveryRoute.getRouteInfo();
+
+        RouteInfo routeInfo = RouteInfo.of(
+                oldRouteInfo.getExpectedDistanceMeters(),
+                oldRouteInfo.getExpectedDurationMinutes(),
+                command.actualDistanceMeters(),
+                command.actualDurationMinutes()
+        );
+
+        deliveryRoute.updateRouteInfo(routeInfo);
+        return DeliveryRouteResult.from(deliveryRoute);
+    }
+
+    @Transactional
+    public void deleteDeliveryRoutesByDeliveryId(UUID userId, UUID deliveryId) {
+        DeliveryRoute deliveryRoute = getDeliveryRouteById(deliveryId);
+        deliveryRoute.delete(userId);
+    }
+
+    private DeliveryRoute getDeliveryRouteById(UUID deliveryRouteId) {
+        return deliveryRouteRepository.findById(deliveryRouteId)
+                .orElseThrow(() -> new DeliveryRouteApplicationException(DeliveryRouteApplicationErrorCode.NOT_FOUND_DELIVERY_ROUTE));
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryRouteService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryRouteService.java
@@ -70,8 +70,7 @@ public class DeliveryRouteService {
     }
 
     @Transactional(readOnly = true)
-    public Page<DeliveryRouteResult> searchDeliveryRoutes(UUID userId, UserRole role, UUID deliveryId, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+    public Page<DeliveryRouteResult> searchDeliveryRoutes(UUID userId, UserRole role, UUID deliveryId, Pageable pageable) {
         Page<DeliveryRoute> deliveryRoutes = deliveryRouteRepository.findAllByDeliveryId(DeliveryId.of(deliveryId), pageable);
         return deliveryRoutes.map(DeliveryRouteResult::from);
     }

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryRouteService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryRouteService.java
@@ -14,7 +14,6 @@ import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryManagerId;
 import com.nowayback.delivery.domain.deliveryroute.vo.RouteInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,8 +29,9 @@ public class DeliveryRouteService {
 
     @Transactional
     public List<DeliveryRouteResult> createDeliveryRoutes(CreateDeliveryRoutesCommand command) {
-        DeliveryId deliveryId = command.deliveryId();
+        validateDuplicateSequence(command.segments());
 
+        DeliveryId deliveryId = command.deliveryId();
         List<DeliveryRoute> deliveryRoutes = command.segments().stream()
                 .map(segment -> createDeliveryRoute(deliveryId, segment))
                 .toList();
@@ -108,5 +108,16 @@ public class DeliveryRouteService {
     private DeliveryRoute getDeliveryRouteById(UUID deliveryRouteId) {
         return deliveryRouteRepository.findById(deliveryRouteId)
                 .orElseThrow(() -> new DeliveryRouteApplicationException(DeliveryRouteApplicationErrorCode.NOT_FOUND_DELIVERY_ROUTE));
+    }
+
+    private void validateDuplicateSequence(List<CreateDeliveryRoutesCommand.DeliveryRouteSegment> segments) {
+        long uniqueCount = segments.stream()
+                .map(CreateDeliveryRoutesCommand.DeliveryRouteSegment::sequence)
+                .distinct()
+                .count();
+
+        if (uniqueCount != segments.size()) {
+            throw new DeliveryRouteApplicationException(DeliveryRouteApplicationErrorCode.DUPLICATE_ROUTE_SEQUENCE);
+        }
     }
 }

--- a/delivery/src/main/java/com/nowayback/delivery/application/command/CreateDeliveryRoutesCommand.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/command/CreateDeliveryRoutesCommand.java
@@ -1,0 +1,47 @@
+package com.nowayback.delivery.application.command;
+
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryId;
+import com.nowayback.delivery.domain.deliveryroute.vo.HubId;
+import com.nowayback.delivery.domain.deliveryroute.vo.HubRoute;
+import com.nowayback.delivery.domain.deliveryroute.vo.RouteSequence;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateDeliveryRoutesCommand (
+        DeliveryId deliveryId,
+        List<DeliveryRouteSegment> segments
+) {
+
+    public static CreateDeliveryRoutesCommand of(
+            UUID deliveryId,
+            List<DeliveryRouteSegment> segments
+    ) {
+        return new CreateDeliveryRoutesCommand(
+                DeliveryId.of(deliveryId),
+                segments
+        );
+    }
+
+    public record DeliveryRouteSegment(
+            RouteSequence sequence,
+            HubRoute hubRoute,
+            int expectedDistanceMeters,
+            int expectedDurationMinutes
+    ) {
+        public static DeliveryRouteSegment of(
+                int sequence,
+                UUID sourceHubId,
+                UUID destinationHubId,
+                int expectedDistanceMeters,
+                int expectedDurationMinutes
+        ) {
+            return new DeliveryRouteSegment(
+                    RouteSequence.of(sequence),
+                    HubRoute.of(HubId.of(sourceHubId), HubId.of(destinationHubId)),
+                    expectedDistanceMeters,
+                    expectedDurationMinutes
+            );
+        }
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/command/UpdateDeliveryRouteInfoCommand.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/command/UpdateDeliveryRouteInfoCommand.java
@@ -1,0 +1,17 @@
+package com.nowayback.delivery.application.command;
+
+public record UpdateDeliveryRouteInfoCommand(
+        int actualDistanceMeters,
+        int actualDurationMinutes
+) {
+
+    public static UpdateDeliveryRouteInfoCommand of(
+            int actualDistanceMeters,
+            int actualDurationMinutes
+    ) {
+        return new UpdateDeliveryRouteInfoCommand(
+                actualDistanceMeters,
+                actualDurationMinutes
+        );
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/command/UpdateDeliveryRouteStatusCommand.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/command/UpdateDeliveryRouteStatusCommand.java
@@ -1,0 +1,14 @@
+package com.nowayback.delivery.application.command;
+
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryRouteStatus;
+
+public record UpdateDeliveryRouteStatusCommand (
+        DeliveryRouteStatus status
+) {
+
+    public static UpdateDeliveryRouteStatusCommand of(
+            DeliveryRouteStatus status
+    ) {
+        return new UpdateDeliveryRouteStatusCommand(status);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/dto/DeliveryRouteResult.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/dto/DeliveryRouteResult.java
@@ -23,7 +23,7 @@ public record DeliveryRouteResult(
                 deliveryRoute.getId(),
                 deliveryRoute.getSequence().getSequence(),
                 deliveryRoute.getHubRoute().getSourceHubId().getId(),
-                deliveryRoute.getHubRoute().getSourceHubId().getId(),
+                deliveryRoute.getHubRoute().getDestinationHubId().getId(),
                 deliveryRoute.getDeliveryManagerId().getId(),
                 deliveryRoute.getStatus(),
                 deliveryRoute.getRouteInfo().getExpectedDistanceMeters(),

--- a/delivery/src/main/java/com/nowayback/delivery/application/dto/DeliveryRouteResult.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/dto/DeliveryRouteResult.java
@@ -1,0 +1,35 @@
+package com.nowayback.delivery.application.dto;
+
+import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryRouteStatus;
+
+import java.util.UUID;
+
+public record DeliveryRouteResult(
+        UUID deliveryRouteId,
+        int sequence,
+        UUID sourceHubId,
+        UUID destinationHubId,
+        UUID hubDeliveryManagerId,
+        DeliveryRouteStatus status,
+        Integer expectedDistanceMeters,
+        Integer expectedDurationMinutes,
+        Integer actualDistanceMeters,
+        Integer actualDurationMinutes
+) {
+
+    public static DeliveryRouteResult from(DeliveryRoute deliveryRoute) {
+        return new DeliveryRouteResult(
+                deliveryRoute.getId(),
+                deliveryRoute.getSequence().getSequence(),
+                deliveryRoute.getHubRoute().getSourceHubId().getId(),
+                deliveryRoute.getHubRoute().getSourceHubId().getId(),
+                deliveryRoute.getDeliveryManagerId().getId(),
+                deliveryRoute.getStatus(),
+                deliveryRoute.getRouteInfo().getExpectedDistanceMeters(),
+                deliveryRoute.getRouteInfo().getExpectedDurationMinutes(),
+                deliveryRoute.getRouteInfo().getActualDistanceMeters(),
+                deliveryRoute.getRouteInfo().getActualDurationMinutes()
+        );
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryRouteApplicationErrorCode.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryRouteApplicationErrorCode.java
@@ -1,0 +1,37 @@
+package com.nowayback.delivery.application.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum DeliveryRouteApplicationErrorCode implements ErrorCode {
+
+    NOT_FOUND_DELIVERY_ROUTE("DELIVERYROUTE2001", "해당 배송 경로를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    DeliveryRouteApplicationErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryRouteApplicationErrorCode.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryRouteApplicationErrorCode.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum DeliveryRouteApplicationErrorCode implements ErrorCode {
 
-    NOT_FOUND_DELIVERY_ROUTE("DELIVERYROUTE2001", "해당 배송 경로를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
-
+    NOT_FOUND_DELIVERY_ROUTE("DELIVERYROUTE2001", "해당 배송 경로를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DUPLICATE_ROUTE_SEQUENCE("DELIVERYROUTE2002", "중복된 경로 시퀀스가 존재합니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String code;

--- a/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryRouteApplicationException.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryRouteApplicationException.java
@@ -1,0 +1,10 @@
+package com.nowayback.delivery.application.exception;
+
+import com.nowayback.common.exception.GlobalException;
+
+public class DeliveryRouteApplicationException extends GlobalException {
+
+    public DeliveryRouteApplicationException(DeliveryRouteApplicationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRoute.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRoute.java
@@ -91,6 +91,10 @@ public class DeliveryRoute extends BaseEntity {
         }
     }
 
+    public void delete(UUID deletedBy) {
+        softDelete(deletedBy);
+    }
+
     private static void validateNotNull(Object value, DeliveryRouteDomainErrorCode errorCode) {
         if (value == null) throw new DeliveryRouteDomainException(errorCode);
     }

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRoute.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRoute.java
@@ -83,12 +83,17 @@ public class DeliveryRoute extends BaseEntity {
         if (!status.canTransitionTo(newStatus)) {
             throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DELIVERY_ROUTE_STATUS_TRANSITION);
         }
+        this.status = newStatus;
     }
 
     public void updateRouteInfo(RouteInfo newRouteInfo) {
+        validateRouteInfo(newRouteInfo);
+
         if (!status.canUpdateRouteInfo()) {
             throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DELIVERY_ROUTE_STATUS_FOR_UPDATE);
         }
+
+        this.routeInfo = newRouteInfo;
     }
 
     public void delete(UUID deletedBy) {

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRoute.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRoute.java
@@ -62,7 +62,7 @@ public class DeliveryRoute extends BaseEntity {
         this.routeInfo = routeInfo;
     }
 
-    public static DeliveryRoute create(DeliveryId deliveryId, RouteSequence sequence, HubRoute hubRoute, DeliveryManagerId deliveryManagerId, DeliveryRouteStatus status, RouteInfo routeInfo) {
+    public static DeliveryRoute create(DeliveryId deliveryId, RouteSequence sequence, HubRoute hubRoute, DeliveryManagerId deliveryManagerId, RouteInfo routeInfo) {
         validateDeliveryId(deliveryId);
         validateRouteSequence(sequence);
         validateHubRoute(hubRoute);
@@ -82,6 +82,12 @@ public class DeliveryRoute extends BaseEntity {
     public void updateStatus(DeliveryRouteStatus newStatus) {
         if (!status.canTransitionTo(newStatus)) {
             throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DELIVERY_ROUTE_STATUS_TRANSITION);
+        }
+    }
+
+    public void updateRouteInfo(RouteInfo newRouteInfo) {
+        if (!status.canUpdateRouteInfo()) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DELIVERY_ROUTE_STATUS_FOR_UPDATE);
         }
     }
 

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRoute.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRoute.java
@@ -1,0 +1,111 @@
+package com.nowayback.delivery.domain.deliveryroute.entity;
+
+import com.nowayback.common.audit.BaseEntity;
+import com.nowayback.delivery.domain.deliveryroute.vo.*;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_delivery_routes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryRoute extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "delivery_route_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "delivery_id", updatable = false, nullable = false))
+    private DeliveryId deliveryId;
+
+    @Embedded
+    @AttributeOverride(name = "sequence", column = @Column(name = "route_sequence", nullable = false))
+    private RouteSequence sequence;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "sourceHubId.id", column = @Column(name = "source_hub_id", nullable = false, updatable = false)),
+            @AttributeOverride(name = "destinationHubId.id", column = @Column(name = "destination_hub_id", nullable = false, updatable = false))
+    })
+    private HubRoute hubRoute;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "delivery_manager_id", nullable = false))
+    private DeliveryManagerId deliveryManagerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private DeliveryRouteStatus status;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "expectedDistanceMeters", column = @Column(name = "expected_distance_meters")),
+            @AttributeOverride(name = "expectedDurationMinutes", column = @Column(name = "expected_duration_minutes")),
+            @AttributeOverride(name = "actualDistanceMeters", column = @Column(name = "actual_distance_meters")),
+            @AttributeOverride(name = "actualDurationMinutes", column = @Column(name = "actual_duration_minutes"))
+    })
+    private RouteInfo routeInfo;
+
+    private DeliveryRoute(DeliveryId deliveryId, RouteSequence sequence, HubRoute hubRoute, DeliveryManagerId deliveryManagerId, DeliveryRouteStatus status, RouteInfo routeInfo) {
+        this.deliveryId = deliveryId;
+        this.sequence = sequence;
+        this.hubRoute = hubRoute;
+        this.deliveryManagerId = deliveryManagerId;
+        this.status = status;
+        this.routeInfo = routeInfo;
+    }
+
+    public static DeliveryRoute create(DeliveryId deliveryId, RouteSequence sequence, HubRoute hubRoute, DeliveryManagerId deliveryManagerId, DeliveryRouteStatus status, RouteInfo routeInfo) {
+        validateDeliveryId(deliveryId);
+        validateRouteSequence(sequence);
+        validateHubRoute(hubRoute);
+        validateDeliveryManagerId(deliveryManagerId);
+        validateRouteInfo(routeInfo);
+
+        return new DeliveryRoute(
+                deliveryId,
+                sequence,
+                hubRoute,
+                deliveryManagerId,
+                DeliveryRouteStatus.WAITING_AT_HUB,
+                routeInfo
+        );
+    }
+
+    public void updateStatus(DeliveryRouteStatus newStatus) {
+        if (!status.canTransitionTo(newStatus)) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DELIVERY_ROUTE_STATUS_TRANSITION);
+        }
+    }
+
+    private static void validateNotNull(Object value, DeliveryRouteDomainErrorCode errorCode) {
+        if (value == null) throw new DeliveryRouteDomainException(errorCode);
+    }
+
+    private static void validateDeliveryId(DeliveryId deliveryId) {
+        validateNotNull(deliveryId, DeliveryRouteDomainErrorCode.NULL_DELIVERY_ID_OBJECT);
+    }
+
+    private static void validateRouteSequence(RouteSequence sequence) {
+        validateNotNull(sequence, DeliveryRouteDomainErrorCode.NULL_ROUTE_SEQUENCE_OBJECT);
+    }
+
+    private static void validateHubRoute(HubRoute hubRoute) {
+        validateNotNull(hubRoute, DeliveryRouteDomainErrorCode.NULL_HUB_ROUTE_OBJECT);
+    }
+
+    private static void validateDeliveryManagerId(DeliveryManagerId deliveryManagerId) {
+        validateNotNull(deliveryManagerId, DeliveryRouteDomainErrorCode.NULL_DELIVERY_MANAGER_ID_OBJECT);
+    }
+
+    private static void validateRouteInfo(RouteInfo routeInfo) {
+        validateNotNull(routeInfo, DeliveryRouteDomainErrorCode.NULL_ROUTE_INFO_OBJECT);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/repository/DeliveryRouteRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/repository/DeliveryRouteRepository.java
@@ -12,5 +12,6 @@ import java.util.UUID;
 public interface DeliveryRouteRepository {
     List<DeliveryRoute> saveAll(List<DeliveryRoute> deliveryRoutes);
     Optional<DeliveryRoute> findById(UUID deliveryRouteId);
+    List<DeliveryRoute> findAllByDeliveryId(DeliveryId deliveryId);
     Page<DeliveryRoute> findAllByDeliveryId(DeliveryId deliveryId, Pageable pageable);
 }

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/repository/DeliveryRouteRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/repository/DeliveryRouteRepository.java
@@ -12,5 +12,5 @@ import java.util.UUID;
 public interface DeliveryRouteRepository {
     List<DeliveryRoute> saveAll(List<DeliveryRoute> deliveryRoutes);
     Optional<DeliveryRoute> findById(UUID deliveryRouteId);
-    Page<DeliveryRoute> findAllByDeliveryId(DeliveryId of, Pageable pageable);
+    Page<DeliveryRoute> findAllByDeliveryId(DeliveryId deliveryId, Pageable pageable);
 }

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/repository/DeliveryRouteRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/repository/DeliveryRouteRepository.java
@@ -1,0 +1,16 @@
+package com.nowayback.delivery.domain.deliveryroute.repository;
+
+import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryRouteRepository {
+    List<DeliveryRoute> saveAll(List<DeliveryRoute> deliveryRoutes);
+    Optional<DeliveryRoute> findById(UUID deliveryRouteId);
+    Page<DeliveryRoute> findAllByDeliveryId(DeliveryId of, Pageable pageable);
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryId.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryId.java
@@ -1,0 +1,31 @@
+package com.nowayback.delivery.domain.deliveryroute.vo;
+
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryId {
+
+    private UUID id;
+
+    private DeliveryId(UUID id) {
+        this.id = id;
+    }
+
+    public static DeliveryId of(UUID id) {
+        if (id == null) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.NULL_DELIVERY_ID_VALUE);
+        }
+        return new DeliveryId(id);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryManagerId.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryManagerId.java
@@ -1,0 +1,31 @@
+package com.nowayback.delivery.domain.deliveryroute.vo;
+
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryManagerId {
+
+    private UUID id;
+
+    private DeliveryManagerId(UUID id) {
+        this.id = id;
+    }
+
+    public static DeliveryManagerId of(UUID id) {
+        if (id == null) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.NULL_DELIVERY_MANAGER_ID_VALUE);
+        }
+        return new DeliveryManagerId(id);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryRouteStatus.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryRouteStatus.java
@@ -32,4 +32,8 @@ public enum DeliveryRouteStatus {
     }
 
     public abstract boolean canTransitionTo(DeliveryRouteStatus newStatus);
+
+    public boolean canUpdateRouteInfo() {
+        return this == WAITING_AT_HUB;
+    }
 }

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryRouteStatus.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryRouteStatus.java
@@ -1,0 +1,35 @@
+package com.nowayback.delivery.domain.deliveryroute.vo;
+
+import lombok.Getter;
+
+@Getter
+public enum DeliveryRouteStatus {
+
+    WAITING_AT_HUB("허브 대기 중") {
+        @Override
+        public boolean canTransitionTo(DeliveryRouteStatus newStatus) {
+            return newStatus == TRANSIT_BETWEEN_HUBS;
+        }
+    },
+    TRANSIT_BETWEEN_HUBS("허브 이동 중") {
+        @Override
+        public boolean canTransitionTo(DeliveryRouteStatus newStatus) {
+            return newStatus == AT_DESTINATION_HUB;
+        }
+    },
+    AT_DESTINATION_HUB("목적지 허브 도착") {
+        @Override
+        public boolean canTransitionTo(DeliveryRouteStatus newStatus) {
+            return false;
+        }
+    },
+    ;
+
+    private final String description;
+
+    DeliveryRouteStatus(String description) {
+        this.description = description;
+    }
+
+    public abstract boolean canTransitionTo(DeliveryRouteStatus newStatus);
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryRouteStatus.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/DeliveryRouteStatus.java
@@ -34,6 +34,6 @@ public enum DeliveryRouteStatus {
     public abstract boolean canTransitionTo(DeliveryRouteStatus newStatus);
 
     public boolean canUpdateRouteInfo() {
-        return this == WAITING_AT_HUB;
+        return this == AT_DESTINATION_HUB;
     }
 }

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/HubId.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/HubId.java
@@ -1,0 +1,31 @@
+package com.nowayback.delivery.domain.deliveryroute.vo;
+
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubId {
+
+    private UUID id;
+
+    private HubId(UUID id) {
+        this.id = id;
+    }
+
+    public static HubId of(UUID id) {
+        if (id == null) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.NULL_HUB_ID_VALUE);
+        }
+        return new HubId(id);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/HubRoute.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/HubRoute.java
@@ -1,0 +1,54 @@
+package com.nowayback.delivery.domain.deliveryroute.vo;
+
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainException;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubRoute {
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "source_hub_id", nullable = false, updatable = false))
+    private HubId sourceHubId;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "destination_hub_id", nullable = false, updatable = false))
+    private HubId destinationHubId;
+
+    private HubRoute(HubId sourceHubId, HubId destinationHubId) {
+        this.sourceHubId = sourceHubId;
+        this.destinationHubId = destinationHubId;
+    }
+
+    public static HubRoute of(HubId sourceHubId, HubId destinationHubId) {
+        validateHubIds(sourceHubId, destinationHubId);
+        validateHubRoute(sourceHubId, destinationHubId);
+
+        return new HubRoute(sourceHubId, destinationHubId);
+    }
+
+    private static void validateHubIds(HubId sourceHubId, HubId destinationHubId) {
+        if (sourceHubId == null) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.NULL_SOURCE_HUB_ID);
+        }
+        if (destinationHubId == null) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.NULL_DESTINATION_HUB_ID);
+        }
+    }
+
+    private static void validateHubRoute(HubId sourceHubId, HubId destinationHubId) {
+        if (sourceHubId.equals(destinationHubId)) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_HUB_ROUTE_SAME_HUB);
+        }
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/RouteInfo.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/RouteInfo.java
@@ -1,0 +1,49 @@
+package com.nowayback.delivery.domain.deliveryroute.vo;
+
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RouteInfo {
+
+    private Integer expectedDistanceMeters;
+    private Integer expectedDurationMinutes;
+    private Integer actualDistanceMeters;
+    private Integer actualDurationMinutes;
+
+    public RouteInfo(Integer expectedDistanceMeters, Integer expectedDurationMinutes, Integer actualDistanceMeters, Integer actualDurationMinutes) {
+        this.expectedDistanceMeters = expectedDistanceMeters;
+        this.expectedDurationMinutes = expectedDurationMinutes;
+        this.actualDistanceMeters = actualDistanceMeters;
+        this.actualDurationMinutes = actualDurationMinutes;
+    }
+
+    public static RouteInfo of(Integer expectedDistanceMeters, Integer expectedDurationMinutes, Integer actualDistanceMeters, Integer actualDurationMinutes) {
+        validateDistanceMeters(expectedDistanceMeters);
+        validateDurationMinutes(expectedDurationMinutes);
+        validateDistanceMeters(actualDistanceMeters);
+        validateDurationMinutes(actualDurationMinutes);
+
+        return new RouteInfo(expectedDistanceMeters, expectedDurationMinutes, actualDistanceMeters, actualDurationMinutes);
+    }
+
+    private static void validateDistanceMeters(Integer distanceMeters) {
+        if (distanceMeters < 0) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DISTANCE_METERS);
+        }
+    }
+
+    private static void validateDurationMinutes(Integer durationMinutes) {
+        if (durationMinutes < 0) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DURATION_MINUTES);
+        }
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/RouteInfo.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/RouteInfo.java
@@ -36,13 +36,13 @@ public class RouteInfo {
     }
 
     private static void validateDistanceMeters(Integer distanceMeters) {
-        if (distanceMeters < 0) {
+        if (distanceMeters != null && distanceMeters < 0) {
             throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DISTANCE_METERS);
         }
     }
 
     private static void validateDurationMinutes(Integer durationMinutes) {
-        if (durationMinutes < 0) {
+        if (durationMinutes != null && durationMinutes < 0) {
             throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_DURATION_MINUTES);
         }
     }

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/RouteSequence.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliveryroute/vo/RouteSequence.java
@@ -1,0 +1,33 @@
+package com.nowayback.delivery.domain.deliveryroute.vo;
+
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RouteSequence {
+
+    private int sequence;
+
+    private RouteSequence(int sequence) {
+        this.sequence = sequence;
+    }
+
+    public static RouteSequence of(int sequence) {
+        validateSequence(sequence);
+        return new RouteSequence(sequence);
+    }
+
+    private static void validateSequence(int sequence) {
+        if (sequence < 0) {
+            throw new DeliveryRouteDomainException(DeliveryRouteDomainErrorCode.INVALID_ROUTE_SEQUENCE);
+        }
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryRouteDomainErrorCode.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryRouteDomainErrorCode.java
@@ -1,0 +1,52 @@
+package com.nowayback.delivery.domain.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum DeliveryRouteDomainErrorCode implements ErrorCode {
+
+    NULL_DELIVERY_ID_VALUE("DELIVERYROUTE1001", "배송 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_DELIVERY_MANAGER_ID_VALUE("DELIVERYROUTE1002", "배송 관리자 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_HUB_ID_VALUE("DELIVERYROUTE1003", "허브 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_SOURCE_HUB_ID("DELIVERYROUTE1004", "출발 허브 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_DESTINATION_HUB_ID("DELIVERYROUTE1005", "도착 허브 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    INVALID_HUB_ROUTE_SAME_HUB("DELIVERYROUTE1006", "출발 허브와 도착 허브는 같을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DISTANCE_METERS("DELIVERYROUTE1007", "거리(미터) 값은 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DURATION_MINUTES("DELIVERYROUTE1008", "소요 시간(분) 값은 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ROUTE_SEQUENCE("DELIVERYROUTE1009", "경로 순서 값은 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+
+    NULL_DELIVERY_ID_OBJECT("DELIVERYROUTE1010", "배송 ID 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_ROUTE_SEQUENCE_OBJECT("DELIVERYROUTE1011", "경로 순서 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_HUB_ROUTE_OBJECT("DELIVERYROUTE1012", "허브 경로 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_DELIVERY_MANAGER_ID_OBJECT("DELIVERYROUTE1013", "배송 관리자 ID 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_ROUTE_INFO_OBJECT("DELIVERYROUTE1014", "경로 정보 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    INVALID_DELIVERY_ROUTE_STATUS_TRANSITION("DELIVERYROUTE1015", "유효하지 않은 배송 경로 상태 전환입니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    DeliveryRouteDomainErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryRouteDomainErrorCode.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryRouteDomainErrorCode.java
@@ -23,6 +23,7 @@ public enum DeliveryRouteDomainErrorCode implements ErrorCode {
     NULL_ROUTE_INFO_OBJECT("DELIVERYROUTE1014", "경로 정보 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_DELIVERY_ROUTE_STATUS_TRANSITION("DELIVERYROUTE1015", "유효하지 않은 배송 경로 상태 전환입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DELIVERY_ROUTE_STATUS_FOR_UPDATE("DELIVERYROUTE1016", "현재 배송 경로 상태에서는 경로 정보를 수정할 수 없습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String code;

--- a/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryRouteDomainException.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryRouteDomainException.java
@@ -1,0 +1,10 @@
+package com.nowayback.delivery.domain.exception;
+
+import com.nowayback.common.exception.GlobalException;
+
+public class DeliveryRouteDomainException extends GlobalException {
+
+    public DeliveryRouteDomainException(DeliveryRouteDomainErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
@@ -11,5 +11,6 @@ import java.util.UUID;
 
 public interface DeliveryRouteJpaRepository extends JpaRepository<DeliveryRoute, UUID> {
     Optional<DeliveryRoute> findByIdAndDeletedAtIsNull(UUID deliveryRouteId);
+    Page<DeliveryRoute> findAllByDeletedAtIsNull(Pageable pageable);
     Page<DeliveryRoute> findAllByDeliveryIdAndDeletedAtIsNull(DeliveryId deliveryId, Pageable pageable);
 }

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
@@ -1,0 +1,15 @@
+package com.nowayback.delivery.infrastructure.repository;
+
+import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryRouteJpaRepository extends JpaRepository<DeliveryRoute, UUID> {
+    Optional<DeliveryRoute> findByIdAndDeletedAtIsNull(UUID deliveryRouteId);
+    Page<DeliveryRoute> findAllByDeliveryIdAndDeletedAtIsNull(DeliveryId deliveryId, Pageable pageable);
+}

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
@@ -6,11 +6,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface DeliveryRouteJpaRepository extends JpaRepository<DeliveryRoute, UUID> {
     Optional<DeliveryRoute> findByIdAndDeletedAtIsNull(UUID deliveryRouteId);
     Page<DeliveryRoute> findAllByDeletedAtIsNull(Pageable pageable);
+    List<DeliveryRoute> findAllByDeliveryIdAndDeletedAtIsNull(DeliveryId deliveryId);
     Page<DeliveryRoute> findAllByDeliveryIdAndDeletedAtIsNull(DeliveryId deliveryId, Pageable pageable);
 }

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
@@ -29,6 +29,11 @@ public class DeliveryRouteRepositoryImpl implements DeliveryRouteRepository {
     }
 
     @Override
+    public List<DeliveryRoute> findAllByDeliveryId(DeliveryId deliveryId) {
+        return deliveryRouteJpaRepository.findAllByDeliveryIdAndDeletedAtIsNull(deliveryId);
+    }
+
+    @Override
     public Page<DeliveryRoute> findAllByDeliveryId(DeliveryId deliveryId, Pageable pageable) {
         if (deliveryId == null) {
             return deliveryRouteJpaRepository.findAllByDeletedAtIsNull(pageable);

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.nowayback.delivery.infrastructure.repository;
+
+import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
+import com.nowayback.delivery.domain.deliveryroute.repository.DeliveryRouteRepository;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryRouteRepositoryImpl implements DeliveryRouteRepository {
+
+    private final DeliveryRouteJpaRepository deliveryRouteJpaRepository;
+
+    @Override
+    public List<DeliveryRoute> saveAll(List<DeliveryRoute> deliveryRoutes) {
+        return deliveryRouteJpaRepository.saveAll(deliveryRoutes);
+    }
+
+    @Override
+    public Optional<DeliveryRoute> findById(UUID deliveryRouteId) {
+        return deliveryRouteJpaRepository.findByIdAndDeletedAtIsNull(deliveryRouteId);
+    }
+
+    @Override
+    public Page<DeliveryRoute> findAllByDeliveryId(DeliveryId deliveryId, Pageable pageable) {
+        return deliveryRouteJpaRepository.findAllByDeliveryIdAndDeletedAtIsNull(deliveryId, pageable);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
@@ -30,6 +30,10 @@ public class DeliveryRouteRepositoryImpl implements DeliveryRouteRepository {
 
     @Override
     public Page<DeliveryRoute> findAllByDeliveryId(DeliveryId deliveryId, Pageable pageable) {
-        return deliveryRouteJpaRepository.findAllByDeliveryIdAndDeletedAtIsNull(deliveryId, pageable);
+        if (deliveryId == null) {
+            return deliveryRouteJpaRepository.findAllByDeletedAtIsNull(pageable);
+        } else {
+            return deliveryRouteJpaRepository.findAllByDeliveryIdAndDeletedAtIsNull(deliveryId, pageable);
+        }
     }
 }

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryRouteController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryRouteController.java
@@ -1,0 +1,86 @@
+package com.nowayback.delivery.presentation;
+
+import com.nowayback.common.dto.PageResponse;
+import com.nowayback.common.security.annotation.AuthUser;
+import com.nowayback.common.security.annotation.CurrentUser;
+import com.nowayback.common.security.annotation.RequireRole;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.delivery.application.DeliveryRouteService;
+import com.nowayback.delivery.application.command.UpdateDeliveryRouteInfoCommand;
+import com.nowayback.delivery.application.command.UpdateDeliveryRouteStatusCommand;
+import com.nowayback.delivery.application.dto.DeliveryRouteResult;
+import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryRouteInfoRequest;
+import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryRouteStatusRequest;
+import com.nowayback.delivery.presentation.dto.response.DeliveryRouteResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/delivery-routes")
+@RequiredArgsConstructor
+public class DeliveryRouteController {
+
+    private final DeliveryRouteService deliveryRouteService;
+
+    @GetMapping("/{deliveryRouteId}")
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER, UserRole.COMPANY_MANAGER})
+    public ResponseEntity<DeliveryRouteResponse> getDeliveryRoute(
+            @CurrentUser AuthUser user,
+            @PathVariable UUID deliveryRouteId
+    ) {
+        return ResponseEntity.ok(
+                DeliveryRouteResponse.from(deliveryRouteService.getDelivery(user.userId(), user.role(), deliveryRouteId))
+        );
+    }
+
+    @GetMapping
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER, UserRole.COMPANY_MANAGER})
+    public ResponseEntity<PageResponse<DeliveryRouteResponse>> searchDeliveryRoutes(
+            @CurrentUser AuthUser user,
+            @RequestParam(required = false) UUID deliveryId,
+            @PageableDefault(page = 0, size = 10, sort = "sequence", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        Page<DeliveryRouteResponse> responses = deliveryRouteService
+                .searchDeliveryRoutes(user.userId(), user.role(), deliveryId, pageable)
+                .map(DeliveryRouteResponse::from);
+
+        return ResponseEntity.ok(PageResponse.fromPage(responses));
+    }
+
+    @PatchMapping("/{deliveryRouteId}/status")
+    @RequireRole({UserRole.MASTER, UserRole.DELIVERY_MANAGER})
+    public ResponseEntity<DeliveryRouteResponse> updateDeliveryRouteStatus(
+            @CurrentUser AuthUser user,
+            @PathVariable UUID deliveryRouteId,
+            @Valid @RequestBody UpdateDeliveryRouteStatusRequest request
+    ) {
+        UpdateDeliveryRouteStatusCommand command = UpdateDeliveryRouteStatusCommand.of(request.deliveryRouteStatus());
+        DeliveryRouteResult result = deliveryRouteService.updateDeliveryRouteStatus(user.userId(), user.role(), deliveryRouteId, command);
+
+        return ResponseEntity.ok(DeliveryRouteResponse.from(result));
+    }
+
+    @PatchMapping("/{deliveryRouteId}")
+    @RequireRole({UserRole.MASTER, UserRole.DELIVERY_MANAGER})
+    public ResponseEntity<DeliveryRouteResponse> updateDeliveryRouteInfo(
+            @CurrentUser AuthUser user,
+            @PathVariable UUID deliveryRouteId,
+            @Valid @RequestBody UpdateDeliveryRouteInfoRequest request
+    ) {
+        UpdateDeliveryRouteInfoCommand command = UpdateDeliveryRouteInfoCommand.of(
+                request.actualDistanceMeters(),
+                request.actualDurationMinutes()
+        );
+        DeliveryRouteResult result = deliveryRouteService.updateDeliveryRouteInfo(user.userId(), user.role(), deliveryRouteId, command);
+
+        return ResponseEntity.ok(DeliveryRouteResponse.from(result));
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/dto/request/UpdateDeliveryRouteInfoRequest.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/dto/request/UpdateDeliveryRouteInfoRequest.java
@@ -1,0 +1,9 @@
+package com.nowayback.delivery.presentation.dto.request;
+
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record UpdateDeliveryRouteInfoRequest(
+        @PositiveOrZero int actualDistanceMeters,
+        @PositiveOrZero int actualDurationMinutes
+) {
+}

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/dto/request/UpdateDeliveryRouteStatusRequest.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/dto/request/UpdateDeliveryRouteStatusRequest.java
@@ -1,0 +1,9 @@
+package com.nowayback.delivery.presentation.dto.request;
+
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryRouteStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateDeliveryRouteStatusRequest(
+        @NotNull DeliveryRouteStatus deliveryRouteStatus
+) {
+}

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/dto/response/DeliveryRouteResponse.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/dto/response/DeliveryRouteResponse.java
@@ -1,0 +1,35 @@
+package com.nowayback.delivery.presentation.dto.response;
+
+import com.nowayback.delivery.application.dto.DeliveryRouteResult;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryRouteStatus;
+
+import java.util.UUID;
+
+public record DeliveryRouteResponse(
+        UUID deliveryRouteId,
+        int sequence,
+        UUID sourceHubId,
+        UUID destinationHubId,
+        UUID hubDeliveryManagerId,
+        DeliveryRouteStatus status,
+        Integer expectedDistanceMeters,
+        Integer expectedDurationMinutes,
+        Integer actualDistanceMeters,
+        Integer actualDurationMinutes
+) {
+
+    public static DeliveryRouteResponse from(DeliveryRouteResult result) {
+        return new DeliveryRouteResponse(
+                result.deliveryRouteId(),
+                result.sequence(),
+                result.sourceHubId(),
+                result.destinationHubId(),
+                result.hubDeliveryManagerId(),
+                result.status(),
+                result.expectedDistanceMeters(),
+                result.expectedDurationMinutes(),
+                result.actualDistanceMeters(),
+                result.actualDurationMinutes()
+        );
+    }
+}

--- a/delivery/src/main/resources/application-local.yaml
+++ b/delivery/src/main/resources/application-local.yaml
@@ -3,7 +3,7 @@ server:
 
 spring:
   datasource:
-    url: ${DELIVERY_SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/delivery_db}
+    url: ${DELIVERY_SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5436/delivery_db}
     username: ${DELIVERY_SPRING_DATASOURCE_USERNAME:user}
     password: ${DELIVERY_SPRING_DATASOURCE_PASSWORD:1234}
     driver-class-name: org.postgresql.Driver

--- a/delivery/src/test/java/com/nowayback/delivery/application/DeliveryRouteServiceTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/application/DeliveryRouteServiceTest.java
@@ -1,0 +1,242 @@
+package com.nowayback.delivery.application;
+
+import com.nowayback.delivery.application.command.CreateDeliveryRoutesCommand;
+import com.nowayback.delivery.application.command.UpdateDeliveryRouteInfoCommand;
+import com.nowayback.delivery.application.command.UpdateDeliveryRouteStatusCommand;
+import com.nowayback.delivery.application.dto.DeliveryRouteResult;
+import com.nowayback.delivery.application.exception.DeliveryRouteApplicationErrorCode;
+import com.nowayback.delivery.application.exception.DeliveryRouteApplicationException;
+import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
+import com.nowayback.delivery.domain.deliveryroute.repository.DeliveryRouteRepository;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryId;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryRouteStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.nowayback.delivery.fixture.DeliveryRouteFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("배송 경로 서비스")
+class DeliveryRouteServiceTest {
+
+    @Mock
+    private DeliveryRouteRepository deliveryRouteRepository;
+
+    @InjectMocks
+    private DeliveryRouteService deliveryRouteService;
+
+    @Nested
+    @DisplayName("배송 경로 생성")
+    class CreateDeliveryRoutes {
+
+        @Test
+        @DisplayName("유효한 정보로 배송 경로를 생성하면 성공한다.")
+        void createDeliveryRoutes_Success() {
+            /* given */
+            CreateDeliveryRoutesCommand command = CREATE_DELIVERY_ROUTES_COMMAND;
+            DeliveryRoute route = createDeliveryRoute();
+
+            when(deliveryRouteRepository.saveAll(anyList()))
+                    .thenReturn(List.of(route));
+
+            /* when */
+            List<DeliveryRouteResult> results = deliveryRouteService.createDeliveryRoutes(command);
+
+            /* then */
+            assertThat(results.size()).isEqualTo(1);
+            assertThat(results.get(0).sequence()).isEqualTo(SEQUENCE);
+            assertThat(results.get(0).sourceHubId()).isEqualTo(SOURCE_HUB_UUID);
+            assertThat(results.get(0).destinationHubId()).isEqualTo(DESTINATION_HUB_UUID);
+            assertThat(results.get(0).hubDeliveryManagerId()).isEqualTo(DELIVERY_MANAGER_UUID);
+            assertThat(results.get(0).status()).isEqualTo(DeliveryRouteStatus.WAITING_AT_HUB);
+            assertThat(results.get(0).expectedDistanceMeters()).isEqualTo(EXPECTED_DISTANCE_METERS);
+            assertThat(results.get(0).expectedDurationMinutes()).isEqualTo(EXPECTED_DURATION_MINUTES);
+            assertThat(results.get(0).actualDistanceMeters()).isNull();
+            assertThat(results.get(0).actualDurationMinutes()).isNull();
+
+            verify(deliveryRouteRepository).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("중복된 순번이 있을 경우 예외가 발생한다.")
+        void createDeliveryRoutes_DuplicateSequence_ShouldThrowException() {
+            /* given */
+            CreateDeliveryRoutesCommand command = CREATE_DELIVERY_ROUTES_COMMAND_WITH_DUPLICATE_SEQUENCE;
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> deliveryRouteService.createDeliveryRoutes(command))
+                    .isInstanceOf(DeliveryRouteApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryRouteApplicationErrorCode.DUPLICATE_ROUTE_SEQUENCE);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 단일 조회")
+    class GetDeliveryRoute {
+
+        @Test
+        @DisplayName("유효한 배송 경로 ID로 조회하면 해당 배송 경로 정보가 반환된다.")
+        void getDeliveryRoute_Success() {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute();
+            UUID deliveryRouteId = DELIVERY_ROUTE_UUID;
+
+            when(deliveryRouteRepository.findById(deliveryRouteId)).thenReturn(Optional.of(route));
+
+            /* when */
+            DeliveryRouteResult result = deliveryRouteService.getDelivery(USER_UUID, USER_ROLE, deliveryRouteId);
+
+            /* then */
+            assertThat(result.sequence()).isEqualTo(SEQUENCE);
+            assertThat(result.sourceHubId()).isEqualTo(SOURCE_HUB_UUID);
+            assertThat(result.destinationHubId()).isEqualTo(DESTINATION_HUB_UUID);
+            assertThat(result.hubDeliveryManagerId()).isEqualTo(DELIVERY_MANAGER_UUID);
+            assertThat(result.status()).isEqualTo(DeliveryRouteStatus.WAITING_AT_HUB);
+            assertThat(result.expectedDistanceMeters()).isEqualTo(EXPECTED_DISTANCE_METERS);
+            assertThat(result.expectedDurationMinutes()).isEqualTo(EXPECTED_DURATION_MINUTES);
+            assertThat(result.actualDistanceMeters()).isNull();
+            assertThat(result.actualDurationMinutes()).isNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송 경로 ID로 조회하면 예외가 발생한다.")
+        void getDeliveryRoute_WithNonExistentId_ShouldThrowException() {
+            /* given */
+            UUID deliveryRouteId = DELIVERY_ROUTE_UUID;
+
+            when(deliveryRouteRepository.findById(deliveryRouteId)).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> deliveryRouteService.getDelivery(USER_UUID, USER_ROLE, deliveryRouteId))
+                    .isInstanceOf(DeliveryRouteApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryRouteApplicationErrorCode.NOT_FOUND_DELIVERY_ROUTE);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 검색 조회")
+    class SearchDeliveryRoutes {
+
+        @Test
+        @DisplayName("검색 조건에 맞는 배송 경로를 조회하면 배송 경로 페이지 목록이 반환된다.")
+        void searchDeliveryRoutes_Success() {
+            /* given */
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("sequence").ascending());
+
+            when(deliveryRouteRepository.findAllByDeliveryId(DELIVERY_ID, pageable))
+                    .thenReturn(DELIVERY_ROUTES_PAGE);
+
+            /* when */
+            Page<DeliveryRouteResult> results = deliveryRouteService
+                    .searchDeliveryRoutes(USER_UUID, USER_ROLE, DELIVERY_UUID, pageable);
+
+            /* then */
+            assertThat(results.getTotalElements()).isEqualTo(DELIVERY_ROUTES.size());
+            assertThat(results.getContent().get(0).sequence()).isEqualTo(SEQUENCE);
+
+            verify(deliveryRouteRepository).findAllByDeliveryId(DELIVERY_ID, pageable);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 상태 수정")
+    class UpdateDeliveryRouteStatus {
+
+        @Test
+        @DisplayName("유효한 정보로 배송 경로 상태를 수정하면 성공한다.")
+        void updateDeliveryRouteStatus_Success() {
+            /* given */
+            UpdateDeliveryRouteStatusCommand command = UPDATE_DELIVERY_ROUTE_STATUS_COMMAND;
+
+            when(deliveryRouteRepository.findById(DELIVERY_ROUTE_UUID)).thenReturn(Optional.of(createDeliveryRoute()));
+
+            /* when */
+            DeliveryRouteResult result = deliveryRouteService.updateDeliveryRouteStatus(USER_UUID, USER_ROLE, DELIVERY_ROUTE_UUID, command);
+
+            /* then */
+            assertThat(result.status()).isEqualTo(command.status());
+
+            verify(deliveryRouteRepository).findById(DELIVERY_ROUTE_UUID);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송 경로 ID로 상태 수정 시도하면 예외가 발생한다.")
+        void updateDeliveryRouteStatus_WithNonExistentId_ShouldThrowException() {
+            /* given */
+            when(deliveryRouteRepository.findById(DELIVERY_ROUTE_UUID)).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> deliveryRouteService.updateDeliveryRouteStatus(USER_UUID, USER_ROLE, DELIVERY_ROUTE_UUID, UPDATE_DELIVERY_ROUTE_STATUS_COMMAND))
+                    .isInstanceOf(DeliveryRouteApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryRouteApplicationErrorCode.NOT_FOUND_DELIVERY_ROUTE);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 정보 수정")
+    class UpdateDeliveryRouteInfo {
+
+        @Test
+        @DisplayName("유효한 정보로 배송 경로 정보를 수정하면 성공한다.")
+        void updateDeliveryRouteInfo_Success() {
+            /* given */
+            UpdateDeliveryRouteInfoCommand command = UPDATE_DELIVERY_ROUTE_INFO_COMMAND;
+
+            when(deliveryRouteRepository.findById(DELIVERY_ROUTE_UUID)).thenReturn(Optional.of(createDeliveryRoute(DeliveryRouteStatus.AT_DESTINATION_HUB)));
+
+            /* when */
+            DeliveryRouteResult result = deliveryRouteService.updateDeliveryRouteInfo(USER_UUID, USER_ROLE, DELIVERY_ROUTE_UUID, command);
+
+            /* then */
+            assertThat(result.actualDistanceMeters()).isEqualTo(command.actualDistanceMeters());
+            assertThat(result.actualDurationMinutes()).isEqualTo(command.actualDurationMinutes());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송 경로 ID로 정보 수정 시도하면 예외가 발생한다.")
+        void updateDeliveryRouteInfo_WithNonExistentId_ShouldThrowException() {
+            /* given */
+            when(deliveryRouteRepository.findById(DELIVERY_ROUTE_UUID)).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> deliveryRouteService.updateDeliveryRouteInfo(USER_UUID, USER_ROLE, DELIVERY_ROUTE_UUID, UPDATE_DELIVERY_ROUTE_INFO_COMMAND))
+                    .isInstanceOf(DeliveryRouteApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryRouteApplicationErrorCode.NOT_FOUND_DELIVERY_ROUTE);
+        }
+    }
+
+    @Test
+    @DisplayName("배송 ID에 대한 배송 경로 삭제")
+    void deleteByDeliveryId_Success() {
+        /* given */
+        UUID deliveryId = DELIVERY_UUID;
+
+        when(deliveryRouteRepository.findAllByDeliveryId(DeliveryId.of(deliveryId)))
+                .thenReturn(DELIVERY_ROUTES);
+
+        /* when */
+        deliveryRouteService.deleteDeliveryRoutesByDeliveryId(USER_UUID, deliveryId);
+
+        /* then */
+        verify(deliveryRouteRepository).findAllByDeliveryId(DeliveryId.of(deliveryId));
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRouteTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/domain/deliveryroute/entity/DeliveryRouteTest.java
@@ -1,0 +1,241 @@
+package com.nowayback.delivery.domain.deliveryroute.entity;
+
+import com.nowayback.delivery.domain.deliveryroute.vo.*;
+import com.nowayback.delivery.domain.exception.DeliveryRouteDomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.UUID;
+
+import static com.nowayback.delivery.fixture.DeliveryRouteFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("배송 경로 엔티티")
+class DeliveryRouteTest {
+
+    @Nested
+    @DisplayName("배송 경로 생성")
+    class CreateDeliveryRoute {
+
+        @Test
+        @DisplayName("모든 필드가 정상일 경우 배송 경로 생성에 성공한다.")
+        void createDeliveryRoute_Success() {
+            /* given */
+            DeliveryId deliveryId = DELIVERY_ID;
+            RouteSequence routeSequence = ROUTE_SEQUENCE;
+            HubRoute hubRoute = HUB_ROUTE;
+            DeliveryManagerId deliveryManagerId = DELIVERY_MANAGER_ID;
+            RouteInfo routeInfo = ROUTE_INFO;
+
+            /* when */
+            DeliveryRoute route = DeliveryRoute.create(deliveryId, routeSequence, hubRoute, deliveryManagerId, routeInfo);
+
+            /* then */
+            assertThat(route.getDeliveryId()).isEqualTo(deliveryId);
+            assertThat(route.getSequence()).isEqualTo(routeSequence);
+            assertThat(route.getHubRoute()).isEqualTo(hubRoute);
+            assertThat(route.getDeliveryManagerId()).isEqualTo(deliveryManagerId);
+            assertThat(route.getRouteInfo()).isEqualTo(routeInfo);
+            assertThat(route.getStatus()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("생성 시 상태는 WAITING_AT_HUB이다.")
+        void createDeliveryRoute_WhenCreate_ShouldHaveWaitingAtHubStatus() {
+            /* given */
+            /* when */
+            DeliveryRoute route = DeliveryRoute.create(DELIVERY_ID, ROUTE_SEQUENCE, HUB_ROUTE, DELIVERY_MANAGER_ID, ROUTE_INFO);
+
+            /* then */
+            assertThat(route.getStatus()).isEqualTo(DeliveryRouteStatus.WAITING_AT_HUB);
+        }
+
+        @Test
+        @DisplayName("배송 ID는 null일 수 없다.")
+        void createDeliveryRoute_WhenDeliveryIdIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> {
+                DeliveryRoute.create(null, ROUTE_SEQUENCE, HUB_ROUTE, DELIVERY_MANAGER_ID, ROUTE_INFO);
+            }).isInstanceOf(DeliveryRouteDomainException.class);
+        }
+
+        @Test
+        @DisplayName("경로 순서는 null일 수 없다.")
+        void createDeliveryRoute_WhenRouteSequenceIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> {
+                DeliveryRoute.create(DELIVERY_ID, null, HUB_ROUTE, DELIVERY_MANAGER_ID, ROUTE_INFO);
+            }).isInstanceOf(DeliveryRouteDomainException.class);
+        }
+
+        @Test
+        @DisplayName("허브 경로는 null일 수 없다.")
+        void createDeliveryRoute_WhenHubRouteIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> {
+                DeliveryRoute.create(DELIVERY_ID, ROUTE_SEQUENCE, null, DELIVERY_MANAGER_ID, ROUTE_INFO);
+            }).isInstanceOf(DeliveryRouteDomainException.class);
+        }
+
+        @Test
+        @DisplayName("배송 담당자 ID는 null일 수 없다.")
+        void createDeliveryRoute_WhenDeliveryManagerIdIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> {
+                DeliveryRoute.create(DELIVERY_ID, ROUTE_SEQUENCE, HUB_ROUTE, null, ROUTE_INFO);
+            }).isInstanceOf(DeliveryRouteDomainException.class);
+        }
+
+        @Test
+        @DisplayName("경로 정보는 null일 수 없다.")
+        void createDeliveryRoute_WhenRouteInfoIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> {
+                DeliveryRoute.create(DELIVERY_ID, ROUTE_SEQUENCE, HUB_ROUTE, DELIVERY_MANAGER_ID, null);
+            }).isInstanceOf(DeliveryRouteDomainException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 상태 수정")
+    class UpdateDeliveryRouteStatus {
+
+        @Test
+        @DisplayName("정상적인 배송 경로 상태 수정 시 성공한다.")
+        void updateDeliveryRouteStatus_Success() {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute();
+            DeliveryRouteStatus newStatus = DeliveryRouteStatus.TRANSIT_BETWEEN_HUBS;
+
+            /* when */
+            route.updateStatus(newStatus);
+
+            /* then */
+            assertThat(route.getStatus()).isEqualTo(newStatus);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "WAITING_AT_HUB,        TRANSIT_BETWEEN_HUBS",
+                "TRANSIT_BETWEEN_HUBS,  AT_DESTINATION_HUB",
+        })
+        @DisplayName("정의된 다음 상태로만 전이할 수 있다.")
+        void updateDeliveryRouteStatus_ValidTransitions_Success(DeliveryRouteStatus initialStatus, DeliveryRouteStatus newStatus) {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute(initialStatus);
+
+            /* when */
+            route.updateStatus(newStatus);
+
+            /* then */
+            assertThat(route.getStatus()).isEqualTo(newStatus);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 상태 전이인 경우 예외가 발생한다.")
+        void updateDeliveryRouteStatus_InvalidTransition_ShouldThrowException() {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute();
+            DeliveryRouteStatus newStatus = DeliveryRouteStatus.AT_DESTINATION_HUB;
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> {
+                route.updateStatus(newStatus);
+            }).isInstanceOf(DeliveryRouteDomainException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 정보 수정")
+    class UpdateDeliveryRouteInfo {
+
+        @Test
+        @DisplayName("정상적인 배송 경로 정보 수정 시 성공한다.")
+        void updateDeliveryRouteInfo_Success() {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute(DeliveryRouteStatus.AT_DESTINATION_HUB);
+            RouteInfo newRouteInfo = MODIFIED_ROUTE_INFO;
+
+            /* when */
+            route.updateRouteInfo(newRouteInfo);
+
+            /* then */
+            assertThat(route.getRouteInfo()).isEqualTo(newRouteInfo);
+        }
+
+        @Test
+        @DisplayName("배송 경로 정보는 null일 수 없다.")
+        void updateDeliveryRouteInfo_WhenRouteInfoIsNull_ShouldThrowException() {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute();
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> {
+                route.updateRouteInfo(null);
+            }).isInstanceOf(DeliveryRouteDomainException.class);
+        }
+
+        @Test
+        @DisplayName("AT_DESTINATION_HUB 상태에서만 경로 정보 수정이 가능하다.")
+        void updateDeliveryRouteInfo_WhenAtDestinationHub_ShouldSucceed() {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute(DeliveryRouteStatus.AT_DESTINATION_HUB);
+
+            /* when */
+            route.updateRouteInfo(MODIFIED_ROUTE_INFO);
+
+            /* then */
+            assertThat(route.getRouteInfo()).isEqualTo(MODIFIED_ROUTE_INFO);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = DeliveryRouteStatus.class, names = {"WAITING_AT_HUB", "TRANSIT_BETWEEN_HUBS"})
+        @DisplayName("AT_DESTINATION_HUB 외의 상태에서는 경로 정보 수정이 불가능하다.")
+        void updateDeliveryRouteInfo_WhenNotAtDestinationHub_ShouldThrowException(DeliveryRouteStatus status) {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute(status);
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> {
+                route.updateRouteInfo(MODIFIED_ROUTE_INFO);
+            }).isInstanceOf(DeliveryRouteDomainException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 삭제")
+    class DeleteDeliveryRoute {
+
+        @Test
+        @DisplayName("삭제 시 소프트 삭제 처리된다.")
+        void deleteDeliveryRoute_Success() {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute();
+            UUID actorId = UUID.randomUUID();
+
+            /* when */
+            route.delete(actorId);
+
+            /* then */
+            assertThat(route.getDeletedAt()).isNotNull();
+            assertThat(route.getDeletedBy()).isEqualTo(actorId);
+        }
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryRouteFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryRouteFixture.java
@@ -1,9 +1,15 @@
 package com.nowayback.delivery.fixture;
 
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.delivery.application.command.CreateDeliveryRoutesCommand;
+import com.nowayback.delivery.application.command.UpdateDeliveryRouteInfoCommand;
+import com.nowayback.delivery.application.command.UpdateDeliveryRouteStatusCommand;
 import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
 import com.nowayback.delivery.domain.deliveryroute.vo.*;
+import org.springframework.data.domain.*;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.UUID;
 
 public class DeliveryRouteFixture {
@@ -42,6 +48,12 @@ public class DeliveryRouteFixture {
             ACTUAL_DURATION_MINUTES
     );
 
+    public static final UUID USER_UUID = UUID.randomUUID();
+    public static final UserRole USER_ROLE = UserRole.MASTER;
+
+    public static final int PAGE = 0;
+    public static final int SIZE = 10;
+
     /* delivery route entity */
     public static DeliveryRoute createDeliveryRoute() {
         return DeliveryRoute.create(
@@ -68,6 +80,39 @@ public class DeliveryRouteFixture {
                 ROUTE_INFO
         );
     }
+
+    private static final Sort SORT = Sort.by("sequence").ascending();
+    public static final Pageable PAGEABLE = PageRequest.of(PAGE, SIZE, SORT);
+    public static final List<DeliveryRoute> DELIVERY_ROUTES = List.of(createDeliveryRoute());
+    public static final Page<DeliveryRoute> DELIVERY_ROUTES_PAGE = new PageImpl<>(DELIVERY_ROUTES, PAGEABLE, DELIVERY_ROUTES.size());
+
+    /* delivery route command */
+    public static final CreateDeliveryRoutesCommand.DeliveryRouteSegment DELIVERY_ROUTE_SEGMENT = CreateDeliveryRoutesCommand.DeliveryRouteSegment.of(
+            SEQUENCE,
+            SOURCE_HUB_UUID,
+            DESTINATION_HUB_UUID,
+            EXPECTED_DISTANCE_METERS,
+            EXPECTED_DURATION_MINUTES
+    );
+
+    public static final CreateDeliveryRoutesCommand CREATE_DELIVERY_ROUTES_COMMAND = CreateDeliveryRoutesCommand.of(
+            DELIVERY_UUID,
+            List.of(DELIVERY_ROUTE_SEGMENT)
+    );
+
+    public static final CreateDeliveryRoutesCommand CREATE_DELIVERY_ROUTES_COMMAND_WITH_DUPLICATE_SEQUENCE = CreateDeliveryRoutesCommand.of(
+            DELIVERY_UUID,
+            List.of(DELIVERY_ROUTE_SEGMENT, DELIVERY_ROUTE_SEGMENT)
+    );
+
+    public static final UpdateDeliveryRouteStatusCommand UPDATE_DELIVERY_ROUTE_STATUS_COMMAND = UpdateDeliveryRouteStatusCommand.of(
+            DeliveryRouteStatus.TRANSIT_BETWEEN_HUBS
+    );
+
+    public static final UpdateDeliveryRouteInfoCommand UPDATE_DELIVERY_ROUTE_INFO_COMMAND = UpdateDeliveryRouteInfoCommand.of(
+            ACTUAL_DISTANCE_METERS,
+            ACTUAL_DURATION_MINUTES
+    );
 
     private static void setPrivateField(Object target, String fieldName, Object value) {
         try {

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryRouteFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryRouteFixture.java
@@ -4,8 +4,11 @@ import com.nowayback.common.security.annotation.UserRole;
 import com.nowayback.delivery.application.command.CreateDeliveryRoutesCommand;
 import com.nowayback.delivery.application.command.UpdateDeliveryRouteInfoCommand;
 import com.nowayback.delivery.application.command.UpdateDeliveryRouteStatusCommand;
+import com.nowayback.delivery.application.dto.DeliveryRouteResult;
 import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
 import com.nowayback.delivery.domain.deliveryroute.vo.*;
+import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryRouteInfoRequest;
+import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryRouteStatusRequest;
 import org.springframework.data.domain.*;
 
 import java.lang.reflect.Field;
@@ -112,6 +115,33 @@ public class DeliveryRouteFixture {
     public static final UpdateDeliveryRouteInfoCommand UPDATE_DELIVERY_ROUTE_INFO_COMMAND = UpdateDeliveryRouteInfoCommand.of(
             ACTUAL_DISTANCE_METERS,
             ACTUAL_DURATION_MINUTES
+    );
+
+    /* delivery route result */
+    public static final DeliveryRouteResult DELIVERY_ROUTE_RESULT = DeliveryRouteResult.from(createDeliveryRoute());
+    public static final Page<DeliveryRouteResult> DELIVERY_ROUTE_RESULT_PAGE = DELIVERY_ROUTES_PAGE.map(DeliveryRouteResult::from);
+
+    public static final DeliveryRouteResult MODIFIED_STATUS_DELIVERY_ROUTE_RESULT = DeliveryRouteResult.from(createDeliveryRoute(DeliveryRouteStatus.TRANSIT_BETWEEN_HUBS));
+    public static DeliveryRouteResult getModifiedInfoDeliveryRouteResult() {
+        DeliveryRoute route = createDeliveryRoute(DeliveryRouteStatus.AT_DESTINATION_HUB);
+        route.updateRouteInfo(MODIFIED_ROUTE_INFO);
+        return DeliveryRouteResult.from(route);
+    }
+
+    /* delivery route request */
+    public static final UpdateDeliveryRouteStatusRequest UPDATE_DELIVERY_ROUTE_STATUS_REQUEST = new UpdateDeliveryRouteStatusRequest(
+            DeliveryRouteStatus.TRANSIT_BETWEEN_HUBS
+    );
+    public static final UpdateDeliveryRouteStatusRequest INVALID_UPDATE_DELIVERY_ROUTE_STATUS_REQUEST = new UpdateDeliveryRouteStatusRequest(
+            null
+    );
+    public static final UpdateDeliveryRouteInfoRequest UPDATE_DELIVERY_ROUTE_INFO_REQUEST = new UpdateDeliveryRouteInfoRequest(
+            ACTUAL_DISTANCE_METERS,
+            ACTUAL_DURATION_MINUTES
+    );
+    public static final UpdateDeliveryRouteInfoRequest INVALID_UPDATE_DELIVERY_ROUTE_INFO_REQUEST = new UpdateDeliveryRouteInfoRequest(
+            -100,
+            100
     );
 
     private static void setPrivateField(Object target, String fieldName, Object value) {

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryRouteFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryRouteFixture.java
@@ -59,6 +59,16 @@ public class DeliveryRouteFixture {
         return route;
     }
 
+    public static DeliveryRoute createDeliveryRoute(DeliveryId deliveryId, RouteSequence routeSequence) {
+        return DeliveryRoute.create(
+                deliveryId,
+                routeSequence,
+                HUB_ROUTE,
+                DELIVERY_MANAGER_ID,
+                ROUTE_INFO
+        );
+    }
+
     private static void setPrivateField(Object target, String fieldName, Object value) {
         try {
             Field field = target.getClass().getDeclaredField(fieldName);

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryRouteFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryRouteFixture.java
@@ -1,0 +1,71 @@
+package com.nowayback.delivery.fixture;
+
+import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
+import com.nowayback.delivery.domain.deliveryroute.vo.*;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+public class DeliveryRouteFixture {
+
+    public static final UUID DELIVERY_ROUTE_UUID = UUID.randomUUID();
+
+    public static final UUID DELIVERY_UUID = UUID.randomUUID();
+    public static final int SEQUENCE = 1;
+    public static final UUID HUB_UUID = UUID.randomUUID();
+    public static final UUID SOURCE_HUB_UUID = UUID.randomUUID();
+    public static final UUID DESTINATION_HUB_UUID = UUID.randomUUID();
+    public static final UUID DELIVERY_MANAGER_UUID = UUID.randomUUID();
+
+    public static final Integer EXPECTED_DISTANCE_METERS = 1000;
+    public static final Integer EXPECTED_DURATION_MINUTES = 15;
+    public static final Integer ACTUAL_DISTANCE_METERS = 1200;
+    public static final Integer ACTUAL_DURATION_MINUTES = 20;
+
+    public static final DeliveryId DELIVERY_ID = DeliveryId.of(DELIVERY_UUID);
+    public static final RouteSequence ROUTE_SEQUENCE = RouteSequence.of(SEQUENCE);
+    public static final HubId HUB_ID = HubId.of(HUB_UUID);
+    public static final HubId SOURCE_HUB_ID = HubId.of(SOURCE_HUB_UUID);
+    public static final HubId DESTINATION_HUB_ID = HubId.of(DESTINATION_HUB_UUID);
+    public static final HubRoute HUB_ROUTE = HubRoute.of(SOURCE_HUB_ID, DESTINATION_HUB_ID);
+    public static final DeliveryManagerId DELIVERY_MANAGER_ID = DeliveryManagerId.of(DELIVERY_MANAGER_UUID);
+    public static final RouteInfo ROUTE_INFO = RouteInfo.of(
+            EXPECTED_DISTANCE_METERS,
+            EXPECTED_DURATION_MINUTES,
+            null,
+            null
+    );
+    public static final RouteInfo MODIFIED_ROUTE_INFO = RouteInfo.of(
+            EXPECTED_DISTANCE_METERS,
+            EXPECTED_DURATION_MINUTES,
+            ACTUAL_DISTANCE_METERS,
+            ACTUAL_DURATION_MINUTES
+    );
+
+    /* delivery route entity */
+    public static DeliveryRoute createDeliveryRoute() {
+        return DeliveryRoute.create(
+                DELIVERY_ID,
+                ROUTE_SEQUENCE,
+                HUB_ROUTE,
+                DELIVERY_MANAGER_ID,
+                ROUTE_INFO
+        );
+    }
+
+    public static DeliveryRoute createDeliveryRoute(DeliveryRouteStatus routeStatus) {
+        DeliveryRoute route = createDeliveryRoute();
+        setPrivateField(route, "status", routeStatus);
+        return route;
+    }
+
+    private static void setPrivateField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryTest.java
@@ -1,0 +1,211 @@
+package com.nowayback.delivery.infrastructure.repository;
+
+import com.nowayback.delivery.domain.deliveryroute.entity.DeliveryRoute;
+import com.nowayback.delivery.domain.deliveryroute.repository.DeliveryRouteRepository;
+import com.nowayback.delivery.domain.deliveryroute.vo.DeliveryId;
+import com.nowayback.delivery.domain.deliveryroute.vo.RouteSequence;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.nowayback.delivery.fixture.DeliveryRouteFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(DeliveryRouteRepositoryImpl.class)
+@EnableJpaAuditing
+@Testcontainers
+@DisplayName("배송 경로 리포지토리")
+class DeliveryRouteRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgre = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private DeliveryRouteRepository deliveryRouteRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Nested
+    @DisplayName("배송 경로 모두 저장")
+    class SaveAll {
+
+        @Test
+        @DisplayName("배송 경로들을 모두 저장한다.")
+        void saveAll_ShouldPersistAllDeliveryRoutes() {
+            /* given */
+            List<DeliveryRoute> routes = List.of(
+                createDeliveryRoute()
+            );
+
+            /* when */
+            List<DeliveryRoute> saved = deliveryRouteRepository.saveAll(routes);
+
+            /* then */
+            for (DeliveryRoute route : saved) {
+                assertThat(route.getId()).isNotNull();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 ID에 대한 배송 경로 조회")
+    class FindById {
+
+        @Test
+        @DisplayName("배송 경로 ID로 배송 경로를 조회한다.")
+        void findById_ExistingId_ShouldReturnDeliveryRoute() {
+            /* given */
+            DeliveryRoute route = createDeliveryRoute();
+
+            entityManager.persist(route);
+            entityManager.flush();
+
+            /* when */
+            Optional<DeliveryRoute> foundRoute = deliveryRouteRepository.findById(route.getId());
+
+            /* then */
+            assertThat(foundRoute).isPresent();
+        }
+
+        @Test
+        @DisplayName("배송 경로 ID에 대한 배송 경로가 존재하지 않으면 빈 Optional을 반환한다.")
+        void findById_NonExistentId_ShouldReturnEmptyOptional() {
+            /* given */
+            /* when */
+            Optional<DeliveryRoute> foundRoute = deliveryRouteRepository.findById(DELIVERY_ROUTE_UUID);
+
+            /* then */
+            assertThat(foundRoute).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("배송 경로 ID에 대한 배송 경로가 삭제된 경우 빈 Optional을 반환한다.")
+        void findById_DeletedRoute_ShouldReturnEmptyOptional() {
+            /* given */
+            DeliveryRoute deletedRoute = createDeliveryRoute();
+            deletedRoute.delete(UUID.randomUUID());
+
+            entityManager.persist(deletedRoute);
+            entityManager.flush();
+
+            /* when */
+            Optional<DeliveryRoute> foundRoute = deliveryRouteRepository.findById(deletedRoute.getId());
+
+            /* then */
+            assertThat(foundRoute).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 검색")
+    class SearchDeliveryRoutes {
+
+        @Test
+        @DisplayName("조건에 맞는 배송 경로들을 반환한다.")
+        void searchDeliveryRoutes_Filtered_ShouldReturnMatchingRoutes() {
+            /* given */
+            DeliveryId deliveryId1 = DeliveryId.of(UUID.randomUUID());
+            DeliveryId deliveryId2 = DeliveryId.of(UUID.randomUUID());
+
+            RouteSequence routeSequence1 = RouteSequence.of(1);
+            RouteSequence routeSequence2 = RouteSequence.of(2);
+
+            DeliveryRoute route1 = createDeliveryRoute(deliveryId1, routeSequence1);
+            DeliveryRoute route2 = createDeliveryRoute(deliveryId1, routeSequence2);
+            DeliveryRoute route3 = createDeliveryRoute(deliveryId2, routeSequence1);
+
+            entityManager.persist(route1);
+            entityManager.persist(route2);
+            entityManager.persist(route3);
+            entityManager.flush();
+
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("sequence").ascending());
+
+            /* when */
+            Page<DeliveryRoute> result = deliveryRouteRepository.findAllByDeliveryId(deliveryId1, pageable);
+
+            /* then */
+            assertThat(result.getTotalElements()).isEqualTo(2);
+
+            for (DeliveryRoute route : result.getContent()) {
+                assertThat(route.getDeliveryId()).isEqualTo(deliveryId1);
+            }
+
+            if (result.getContent().size() > 1) {
+                assertThat(result.getContent())
+                        .isSortedAccordingTo(Comparator.comparing(route -> route.getSequence().getSequence()));
+            }
+        }
+
+        @Test
+        @DisplayName("조건이 없으면 모든 활성 배송 경로들을 반환한다.")
+        void searchDeliveryRoutes_NoFilters_ShouldReturnAllActiveRoutes() {
+            /* given */
+            DeliveryId deliveryId1 = DeliveryId.of(UUID.randomUUID());
+            DeliveryId deliveryId2 = DeliveryId.of(UUID.randomUUID());
+            DeliveryId deliveryId3 = DeliveryId.of(UUID.randomUUID());
+
+            RouteSequence routeSequence = RouteSequence.of(1);
+
+            DeliveryRoute route1 = createDeliveryRoute(deliveryId1, routeSequence);
+            DeliveryRoute route2 = createDeliveryRoute(deliveryId2, routeSequence);
+            DeliveryRoute route3 = createDeliveryRoute(deliveryId3, routeSequence);
+            DeliveryRoute deletedRoute = createDeliveryRoute(deliveryId1, routeSequence);
+            deletedRoute.delete(UUID.randomUUID());
+
+            entityManager.persist(route1);
+            entityManager.persist(route2);
+            entityManager.persist(route3);
+            entityManager.persist(deletedRoute);
+            entityManager.flush();
+
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+            /* when */
+            Page<DeliveryRoute> result = deliveryRouteRepository.findAllByDeliveryId(null, pageable);
+
+            /* then */
+            assertThat(result.getTotalElements()).isEqualTo(3);
+            assertThat(result.getContent()).noneMatch(r -> r.getDeletedAt() != null);
+
+            if (result.getContent().size() > 1) {
+                assertThat(result.getContent())
+                        .isSortedAccordingTo(Comparator.comparing(DeliveryRoute::getCreatedAt).reversed());
+            }
+        }
+
+        @Test
+        @DisplayName("조건에 맞는 배송 경로가 없으면 빈 페이지를 반환한다.")
+        void searchDeliveryRoutes_NoMatchingRoutes_ShouldReturnEmptyPage() {
+            /* given */
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("sequence").ascending());
+
+            /* when */
+            Page<DeliveryRoute> result = deliveryRouteRepository.findAllByDeliveryId(DELIVERY_ID, pageable);
+
+            /* then */
+            assertThat(result.getContent()).isEmpty();
+        }
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/infrastructure/repository/DeliveryRouteRepositoryTest.java
@@ -116,6 +116,43 @@ class DeliveryRouteRepositoryTest {
             assertThat(foundRoute).isNotPresent();
         }
     }
+    
+    @Nested
+    @DisplayName("배송 ID에 대한 배송 경로들 조회")
+    class findAllByDeliveryId {
+        
+        @Test
+        @DisplayName("배송 ID로 배송 경로들을 조회한다.")
+        void findAllByDeliveryId_ExistingDeliveryId_ShouldReturnDeliveryRoutes() {
+            /* given */
+            DeliveryRoute route1 = createDeliveryRoute(DELIVERY_ID, RouteSequence.of(1));
+            DeliveryRoute route2 = createDeliveryRoute(DELIVERY_ID, RouteSequence.of(2));
+
+            entityManager.persist(route1);
+            entityManager.persist(route2);
+            entityManager.flush();
+
+            /* when */
+            List<DeliveryRoute> foundRoutes = deliveryRouteRepository.findAllByDeliveryId(DELIVERY_ID);
+            
+            /* then */
+            assertThat(foundRoutes).hasSize(2);
+            for (DeliveryRoute route : foundRoutes) {
+                assertThat(route.getDeliveryId()).isEqualTo(DELIVERY_ID);
+            }
+        }
+
+        @Test
+        @DisplayName("배송 ID에 대한 배송 경로들이 존재하지 않으면 빈 리스트를 반환한다.")
+        void findAllByDeliveryId_NonExistentDeliveryId_ShouldReturnEmptyList() {
+            /* given */
+            /* when */
+            List<DeliveryRoute> foundRoutes = deliveryRouteRepository.findAllByDeliveryId(DELIVERY_ID);
+
+            /* then */
+            assertThat(foundRoutes).isEmpty();
+        }
+    }
 
     @Nested
     @DisplayName("배송 경로 검색")

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryRouteControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryRouteControllerTest.java
@@ -1,0 +1,274 @@
+package com.nowayback.delivery.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.delivery.application.DeliveryRouteService;
+import com.nowayback.delivery.application.dto.DeliveryRouteResult;
+import com.nowayback.delivery.fixture.DeliveryRouteFixture;
+import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryRouteInfoRequest;
+import com.nowayback.delivery.presentation.dto.request.UpdateDeliveryRouteStatusRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static com.nowayback.delivery.fixture.DeliveryRouteFixture.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(DeliveryRouteController.class)
+@DisplayName("배송 경로 컨트롤러")
+class DeliveryRouteControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private DeliveryRouteService deliveryRouteService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final String BASE_URL = "/delivery-routes";
+
+    @Nested
+    @DisplayName("배송 경로 단일 조회 API")
+    class GetDeliveryRoute {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER", "DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("유효한 요청이 들어오면 배송 경로를 조회한다.")
+        void getDeliveryRoute_Success(UserRole role) throws Exception {
+            /* given */
+            DeliveryRouteResult result = DELIVERY_ROUTE_RESULT;
+
+            given(deliveryRouteService.getDelivery(any(), eq(role), eq(DELIVERY_ROUTE_UUID))).willReturn(result);
+
+            /* when */
+            /* then */
+            performWithAuth(get(BASE_URL + "/{deliveryRouteId}", DELIVERY_ROUTE_UUID), role)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.sequence").value(SEQUENCE))
+                    .andExpect(jsonPath("$.sourceHubId").value(SOURCE_HUB_UUID.toString()))
+                    .andExpect(jsonPath("$.destinationHubId").value(DESTINATION_HUB_UUID.toString()))
+                    .andExpect(jsonPath("$.hubDeliveryManagerId").value(DELIVERY_MANAGER_UUID.toString()))
+                    .andExpect(jsonPath("$.expectedDistanceMeters").value(EXPECTED_DISTANCE_METERS))
+                    .andExpect(jsonPath("$.expectedDurationMinutes").value(EXPECTED_DURATION_MINUTES))
+                    .andExpect(jsonPath("$.actualDistanceMeters").isEmpty())
+                    .andExpect(jsonPath("$.actualDurationMinutes").isEmpty());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void getDeliveryRoute_Unauthenticated_Failure() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(get(BASE_URL + "/{deliveryRouteId}", DELIVERY_ROUTE_UUID))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 검색 API")
+    class SearchDeliveryRoutes {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER", "DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("유효한 요청이 들어오면 배송 경로 목록을 조회한다.")
+        void searchDeliveryRoutes_Success(UserRole role) throws Exception {
+            /* given */
+            Pageable pageable = PAGEABLE;
+
+            given(deliveryRouteService.searchDeliveryRoutes(any(), eq(role), eq(DELIVERY_UUID), eq(pageable)))
+                    .willReturn(DeliveryRouteFixture.DELIVERY_ROUTE_RESULT_PAGE);
+
+            /* when */
+            /* then */
+            performWithAuth(get(BASE_URL)
+                            .param("deliveryId", DELIVERY_UUID.toString())
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize()))
+                            .param("sort", "sequence,asc"),
+                    role)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.items.length()").value(1))
+                    .andExpect(jsonPath("$.items[0].sequence").value(SEQUENCE))
+                    .andExpect(jsonPath("$.items[0].sourceHubId").value(SOURCE_HUB_UUID.toString()))
+                    .andExpect(jsonPath("$.items[0].destinationHubId").value(DESTINATION_HUB_UUID.toString()))
+                    .andExpect(jsonPath("$.items[0].hubDeliveryManagerId").value(DELIVERY_MANAGER_UUID.toString()))
+                    .andExpect(jsonPath("$.items[0].expectedDistanceMeters").value(EXPECTED_DISTANCE_METERS))
+                    .andExpect(jsonPath("$.items[0].expectedDurationMinutes").value(EXPECTED_DURATION_MINUTES))
+                    .andExpect(jsonPath("$.items[0].actualDistanceMeters").isEmpty())
+                    .andExpect(jsonPath("$.items[0].actualDurationMinutes").isEmpty());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void searchDeliveryRoutes_Unauthenticated_Failure() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(get(BASE_URL)
+                            .param("deliveryId", DELIVERY_UUID.toString())
+                            .param("page", String.valueOf(PAGE))
+                            .param("size", String.valueOf(SIZE))
+                            .param("sort", "sequence,asc"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 상태 수정 API")
+    class UpdateDeliveryRouteStatus {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "DELIVERY_MANAGER"})
+        @DisplayName("유효한 요청이 들어오면 배송 경로 상태를 수정한다.")
+        void updateDeliveryRouteStatus_Success(UserRole role) throws Exception {
+            /* given */
+            UpdateDeliveryRouteStatusRequest request = UPDATE_DELIVERY_ROUTE_STATUS_REQUEST;
+            DeliveryRouteResult result = MODIFIED_STATUS_DELIVERY_ROUTE_RESULT;
+
+            given(deliveryRouteService.updateDeliveryRouteStatus(any(), eq(role), eq(DELIVERY_ROUTE_UUID), any()))
+                    .willReturn(result);
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{deliveryRouteId}/status", DELIVERY_ROUTE_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.sequence").value(SEQUENCE))
+                    .andExpect(jsonPath("$.sourceHubId").value(SOURCE_HUB_UUID.toString()))
+                    .andExpect(jsonPath("$.destinationHubId").value(DESTINATION_HUB_UUID.toString()))
+                    .andExpect(jsonPath("$.hubDeliveryManagerId").value(DELIVERY_MANAGER_UUID.toString()))
+                    .andExpect(jsonPath("$.status").value(request.deliveryRouteStatus().toString()))
+                    .andExpect(jsonPath("$.expectedDistanceMeters").value(EXPECTED_DISTANCE_METERS))
+                    .andExpect(jsonPath("$.expectedDurationMinutes").value(EXPECTED_DURATION_MINUTES))
+                    .andExpect(jsonPath("$.actualDistanceMeters").isEmpty())
+                    .andExpect(jsonPath("$.actualDurationMinutes").isEmpty());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청이 들어오면 응답코드 400을 반환한다.")
+        void updateDeliveryRouteStatus_InvalidRequest_Failure() throws Exception {
+            /* given */
+            UpdateDeliveryRouteStatusRequest request = INVALID_UPDATE_DELIVERY_ROUTE_STATUS_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{deliveryRouteId}/status", DELIVERY_ROUTE_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void updateDeliveryRouteStatus_Unauthenticated_Failure() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(patch(BASE_URL + "/{deliveryRouteId}/status", DELIVERY_ROUTE_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(UPDATE_DELIVERY_ROUTE_STATUS_REQUEST)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"HUB_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void updateDeliveryRouteStatus_Forbidden_Failure(UserRole role) throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{deliveryRouteId}/status", DELIVERY_ROUTE_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(UPDATE_DELIVERY_ROUTE_STATUS_REQUEST)),
+                    role)
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 경로 정보 수정 API")
+    class UpdateDeliveryRouteInfo {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "DELIVERY_MANAGER"})
+        @DisplayName("유효한 요청이 들어오면 배송 경로 정보를 수정한다.")
+        void updateDeliveryRouteInfo_Success() throws Exception {
+            /* given */
+            UpdateDeliveryRouteInfoRequest request = UPDATE_DELIVERY_ROUTE_INFO_REQUEST;
+            DeliveryRouteResult result = getModifiedInfoDeliveryRouteResult();
+
+            given(deliveryRouteService.updateDeliveryRouteInfo(any(), eq(UserRole.DELIVERY_MANAGER), eq(DELIVERY_ROUTE_UUID), any()))
+                    .willReturn(result);
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{deliveryRouteId}", DELIVERY_ROUTE_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.DELIVERY_MANAGER)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.sequence").value(SEQUENCE))
+                    .andExpect(jsonPath("$.sourceHubId").value(SOURCE_HUB_UUID.toString()))
+                    .andExpect(jsonPath("$.destinationHubId").value(DESTINATION_HUB_UUID.toString()))
+                    .andExpect(jsonPath("$.hubDeliveryManagerId").value(DELIVERY_MANAGER_UUID.toString()))
+                    .andExpect(jsonPath("$.expectedDistanceMeters").value(EXPECTED_DISTANCE_METERS))
+                    .andExpect(jsonPath("$.expectedDurationMinutes").value(EXPECTED_DURATION_MINUTES))
+                    .andExpect(jsonPath("$.actualDistanceMeters").value(request.actualDistanceMeters()))
+                    .andExpect(jsonPath("$.actualDurationMinutes").value(request.actualDurationMinutes()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청이 들어오면 응답코드 400을 반환한다.")
+        void updateDeliveryRouteInfo_InvalidRequest_Failure() throws Exception {
+            /* given */
+            UpdateDeliveryRouteInfoRequest request = INVALID_UPDATE_DELIVERY_ROUTE_INFO_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{deliveryRouteId}", DELIVERY_ROUTE_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)),
+                    UserRole.DELIVERY_MANAGER)
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void updateDeliveryRouteInfo_Unauthenticated_Failure() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(patch(BASE_URL + "/{deliveryRouteId}", DELIVERY_ROUTE_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(UPDATE_DELIVERY_ROUTE_INFO_REQUEST)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"HUB_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void updateDeliveryRouteInfo_Forbidden_Failure(UserRole role) throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{deliveryRouteId}", DELIVERY_ROUTE_UUID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(UPDATE_DELIVERY_ROUTE_INFO_REQUEST)),
+                    role)
+                    .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #49 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
배송 경로와 관련된 엔티티, 리포지토리, 서비스, 컨트롤러 구현
- 배송 경로 엔티티
  - `DeliveryId`, `RouteSequence`, `HubRoute`, `DeliveryManagerId`, `DeliveryRouteStatus`, `RouteInfo`로의 VO 분리
  - 배송 경로 생성 시 각 VO에 대한 null 체크 수행
  - 배송 경로 상태 수정 시, 전이 상태로만 수정 가능하도록 검증 수행
  - 배송 경로 정보 수정 시, 경로 정보 null 체크와 AT_DESTINATION_HUB 상태에서만 가능하도록 검증
- 배송 경로 서비스
  - `createDeliveryRoutes` : 배송 경로 여러 개를 받아 배송에 대한 배송 경로들을 생성
    - 동일한 sequence를 가진 경로가 있을 경우 예외
  - `getDelivery` : 배송 경로 아이디에 대한 단일 조회
  - `searchDeliveryRoute` : 배송 아이디(null 가능)와 정렬 기준을 통한 배송 경로 검색 조회
  - `updateDeliveryRouteStatus` : 배송 경로 상태 수정
  - `updateDeliveryRouteInfo` : 배송 경로 정보 수정
- 배송 경로 컨트롤러
  - 배송 경로 단일 조회 (모든 Role 가능)
  - 배송 경로 검색 (모든 Role 가능)
  - 배송 경로 상태 변경 (`MASTER`, `DELIVERY_MANAGER` 가능)
  - 배송 경로 정보 변경 (`MASTER`, `DELIVERY_MANAGER` 가능)
## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
배송 경로 엔티티, 리포지토리, 서비스, 컨트롤러에 대한 테스트 코드 확인 부탁드립니다! (모두 통과)

## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
배송과 관련된 연쇄 수행 전 입니다! (배송 + 배송 경로 + 배송 담당자 구현 후 수정 예정입니다)
로직이 의도대로 잘 작성되었는지 확인 부탁드립니다!