### PR TITLE
[#50] 배송 담당자 도메인 API 구현

### DIFF
--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryManagerService.java
@@ -13,7 +13,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +24,8 @@ public class DeliveryManagerService {
 
     private final DeliveryManagerRepository deliveryManagerRepository;
     private final UserClient userClient;
+
+    private final Map<DeliveryManagerType, Integer> roundRobinIndex = new ConcurrentHashMap<>();
 
     @Transactional
     public DeliveryManagerResult createDeliveryManager(CreateDeliveryManagerCommand command) {
@@ -47,6 +52,20 @@ public class DeliveryManagerService {
     public DeliveryManagerResult getDeliveryManager(UUID deliveryManagerId) {
         DeliveryManager deliveryManager = getDeliveryManagerById(deliveryManagerId);
         return DeliveryManagerResult.from(deliveryManager);
+    }
+
+    @Transactional(readOnly = true)
+    public UUID assignDeliveryManager(DeliveryManagerType type) {
+        List<DeliveryManager> managers = deliveryManagerRepository.findAllByTypeOrderBySequenceAsc(type);
+
+        if (managers.isEmpty()) {
+            throw new DeliveryManagerApplicationException(DeliveryManagerApplicationErrorCode.NOT_FOUND_DELIVERY_MANAGER);
+        }
+
+        int index = roundRobinIndex
+                .compute(type, (key, value) -> value == null ? 0 : (value + 1) % managers.size());
+
+        return managers.get(index).getId();
     }
 
     @Transactional

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryManagerService.java
@@ -85,7 +85,7 @@ public class DeliveryManagerService {
     }
 
     private void validateDuplicateDeliveryManagerId(UUID userId) {
-        if (deliveryManagerRepository.findById(userId).isPresent()) {
+        if (deliveryManagerRepository.existsById(userId)) {
             throw new DeliveryManagerApplicationException(DeliveryManagerApplicationErrorCode.DUPLICATE_DELIVERY_MANAGER_ID);
         }
     }

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryManagerService.java
@@ -32,7 +32,7 @@ public class DeliveryManagerService {
         validateDuplicateDeliveryManagerId(command.userId());
 
         DeliveryManagerType type = command.type();
-        DeliverySequence sequence = DeliverySequence.of(getMaxDeliveryManagerSequence(type));
+        DeliverySequence sequence = DeliverySequence.of(getMaxDeliveryManagerSequence(type) + 1);
 
         String slackId = userClient.getUserInfoById(command.userId()).slackId();
 

--- a/delivery/src/main/java/com/nowayback/delivery/application/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/DeliveryManagerService.java
@@ -1,0 +1,73 @@
+package com.nowayback.delivery.application;
+
+import com.nowayback.delivery.application.command.CreateDeliveryManagerCommand;
+import com.nowayback.delivery.application.dto.DeliveryManagerResult;
+import com.nowayback.delivery.application.exception.DeliveryManagerApplicationErrorCode;
+import com.nowayback.delivery.application.exception.DeliveryManagerApplicationException;
+import com.nowayback.delivery.application.service.UserClient;
+import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
+import com.nowayback.delivery.domain.deliverymanager.repository.DeliveryManagerRepository;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryManagerService {
+
+    private final DeliveryManagerRepository deliveryManagerRepository;
+    private final UserClient userClient;
+
+    @Transactional
+    public DeliveryManagerResult createDeliveryManager(CreateDeliveryManagerCommand command) {
+        validateDuplicateDeliveryManagerId(command.userId());
+
+        DeliveryManagerType type = command.type();
+        DeliverySequence sequence = DeliverySequence.of(getMaxDeliveryManagerSequence(type));
+
+        String slackId = userClient.getUserInfoById(command.userId()).slackId();
+
+        DeliveryManager deliveryManager = DeliveryManager.create(
+                command.userId(),
+                command.hubId(),
+                type,
+                slackId,
+                sequence
+        );
+
+        DeliveryManager savedDeliveryManager = deliveryManagerRepository.save(deliveryManager);
+        return DeliveryManagerResult.from(savedDeliveryManager);
+    }
+
+    @Transactional(readOnly = true)
+    public DeliveryManagerResult getDeliveryManager(UUID deliveryManagerId) {
+        DeliveryManager deliveryManager = getDeliveryManagerById(deliveryManagerId);
+        return DeliveryManagerResult.from(deliveryManager);
+    }
+
+    @Transactional
+    public void deleteDeliveryManager(UUID actorId, UUID deliveryManagerId) {
+        DeliveryManager deliveryManager = getDeliveryManagerById(deliveryManagerId);
+        deliveryManager.delete(actorId);
+    }
+
+    private DeliveryManager getDeliveryManagerById(UUID deliveryManagerId) {
+        return deliveryManagerRepository.findById(deliveryManagerId)
+                .orElseThrow(() -> new DeliveryManagerApplicationException(DeliveryManagerApplicationErrorCode.NOT_FOUND_DELIVERY_MANAGER));
+    }
+
+    private int getMaxDeliveryManagerSequence(DeliveryManagerType type) {
+        Integer maxSequence = deliveryManagerRepository.findMaxSequenceByType(type);
+        return maxSequence != null ? maxSequence : 0;
+    }
+
+    private void validateDuplicateDeliveryManagerId(UUID userId) {
+        if (deliveryManagerRepository.findById(userId).isPresent()) {
+            throw new DeliveryManagerApplicationException(DeliveryManagerApplicationErrorCode.DUPLICATE_DELIVERY_MANAGER_ID);
+        }
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/command/CreateDeliveryManagerCommand.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/command/CreateDeliveryManagerCommand.java
@@ -1,0 +1,25 @@
+package com.nowayback.delivery.application.command;
+
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import com.nowayback.delivery.domain.deliverymanager.vo.HubId;
+
+import java.util.UUID;
+
+public record CreateDeliveryManagerCommand(
+        UUID userId,
+        HubId hubId,
+        DeliveryManagerType type
+) {
+
+    public static CreateDeliveryManagerCommand of(
+            UUID userId,
+            UUID hubId,
+            DeliveryManagerType type
+    ) {
+        return new CreateDeliveryManagerCommand(
+                userId,
+                HubId.of(hubId),
+                type
+        );
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/dto/DeliveryManagerResult.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/dto/DeliveryManagerResult.java
@@ -1,0 +1,25 @@
+package com.nowayback.delivery.application.dto;
+
+import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+
+import java.util.UUID;
+
+public record DeliveryManagerResult(
+        UUID deliveryManagerId,
+        UUID hubId,
+        DeliveryManagerType type,
+        String slackId,
+        int sequence
+) {
+
+    public static DeliveryManagerResult from(DeliveryManager deliveryManager) {
+        return new DeliveryManagerResult(
+                deliveryManager.getId(),
+                deliveryManager.getHubId().getId(),
+                deliveryManager.getType(),
+                deliveryManager.getSlackId(),
+                deliveryManager.getDeliverySequence().getSequence()
+        );
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryManagerApplicationErrorCode.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryManagerApplicationErrorCode.java
@@ -1,0 +1,36 @@
+package com.nowayback.delivery.application.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum DeliveryManagerApplicationErrorCode implements ErrorCode {
+    DUPLICATE_DELIVERY_MANAGER_SEQUENCE("DELIVERYMGR2001", "이미 존재하는 배송 관리자 시퀀스입니다.", HttpStatus.CONFLICT),
+    DUPLICATE_DELIVERY_MANAGER_ID("DELIVERYMGR2002", "이미 존재하는 배송 관리자 ID입니다.", HttpStatus.CONFLICT),
+    NOT_FOUND_DELIVERY_MANAGER("DELIVERYMGR2003", "존재하지 않는 배송 관리자입니다.", HttpStatus.NOT_FOUND),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    DeliveryManagerApplicationErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryManagerApplicationException.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/exception/DeliveryManagerApplicationException.java
@@ -1,0 +1,10 @@
+package com.nowayback.delivery.application.exception;
+
+import com.nowayback.common.exception.GlobalException;
+
+public class DeliveryManagerApplicationException extends GlobalException {
+
+    public DeliveryManagerApplicationException(DeliveryManagerApplicationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/application/service/UserClient.java
+++ b/delivery/src/main/java/com/nowayback/delivery/application/service/UserClient.java
@@ -1,0 +1,11 @@
+package com.nowayback.delivery.application.service;
+
+import java.util.UUID;
+
+public interface UserClient {
+    UserInfo getUserInfoById(UUID userId);
+
+    record UserInfo(
+            String slackId
+    ) {}
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/entity/DeliveryManager.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/entity/DeliveryManager.java
@@ -1,0 +1,97 @@
+package com.nowayback.delivery.domain.deliverymanager.entity;
+
+import com.nowayback.common.audit.BaseEntity;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
+import com.nowayback.delivery.domain.deliverymanager.vo.HubId;
+import com.nowayback.delivery.domain.exception.DeliveryManagerDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryManagerDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_delivery_managers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryManager extends BaseEntity {
+
+    @Id
+    @Column(name = "delivery_manager_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "hub_id", nullable = false))
+    private HubId hubId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "manager_type", nullable = false)
+    private DeliveryManagerType type;
+
+    @Column(name = "slack_id", nullable = false)
+    private String slackId;
+
+    @Embedded
+    @AttributeOverride(name = "sequence", column = @Column(name = "delivery_sequence", nullable = false))
+    private DeliverySequence deliverySequence;
+
+    public DeliveryManager(UUID id, HubId hubId, DeliveryManagerType type, String slackId, DeliverySequence deliverySequence) {
+        this.id = id;
+        this.hubId = hubId;
+        this.type = type;
+        this.slackId = slackId;
+        this.deliverySequence = deliverySequence;
+    }
+
+    public static DeliveryManager create(UUID userId, HubId hubId, DeliveryManagerType type, String slackId, DeliverySequence deliverySequence) {
+        validateHubId(hubId);
+        validateDeliveryManagerType(type);
+        validateSlackId(slackId);
+        validateDeliverySequence(deliverySequence);
+
+        return new DeliveryManager(
+                userId,
+                hubId,
+                type,
+                slackId,
+                deliverySequence
+        );
+    }
+
+    public void delete(UUID deletedBy) {
+        softDelete(deletedBy);
+    }
+
+    private static void validateUserId(UUID userId) {
+        if (userId == null) {
+            throw new DeliveryManagerDomainException(DeliveryManagerDomainErrorCode.NULL_USER_ID_VALUE);
+        }
+    }
+
+    private static void validateHubId(HubId hubId) {
+        if (hubId == null) {
+            throw new DeliveryManagerDomainException(DeliveryManagerDomainErrorCode.NULL_HUB_ID_OBJECT);
+        }
+    }
+
+    private static void validateDeliveryManagerType(DeliveryManagerType type) {
+        if (type == null) {
+            throw new DeliveryManagerDomainException(DeliveryManagerDomainErrorCode.NULL_DELIVERY_MANAGER_TYPE_OBJECT);
+        }
+    }
+
+    private static void validateSlackId(String slackId) {
+        if (slackId == null || slackId.isBlank()) {
+            throw new DeliveryManagerDomainException(DeliveryManagerDomainErrorCode.NULL_SLACK_ID_VALUE);
+        }
+    }
+
+    private static void validateDeliverySequence(DeliverySequence deliverySequence) {
+        if (deliverySequence == null) {
+            throw new DeliveryManagerDomainException(DeliveryManagerDomainErrorCode.NULL_DELIVERY_SEQUENCE_OBJECT);
+        }
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/entity/DeliveryManager.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/entity/DeliveryManager.java
@@ -47,6 +47,7 @@ public class DeliveryManager extends BaseEntity {
     }
 
     public static DeliveryManager create(UUID userId, HubId hubId, DeliveryManagerType type, String slackId, DeliverySequence deliverySequence) {
+        validateUserId(userId);
         validateHubId(hubId);
         validateDeliveryManagerType(type);
         validateSlackId(slackId);

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/repository/DeliveryManagerRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/repository/DeliveryManagerRepository.java
@@ -1,0 +1,14 @@
+package com.nowayback.delivery.domain.deliverymanager.repository;
+
+import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryManagerRepository {
+    DeliveryManager save(DeliveryManager deliveryManager);
+    Integer findMaxSequenceByType(DeliveryManagerType type);
+    Optional<DeliveryManager> findById(UUID deliveryManagerId);
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/repository/DeliveryManagerRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/repository/DeliveryManagerRepository.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 public interface DeliveryManagerRepository {
     DeliveryManager save(DeliveryManager deliveryManager);
+    boolean existsById(UUID userId);
     Integer findMaxSequenceByType(DeliveryManagerType type);
     Optional<DeliveryManager> findById(UUID deliveryManagerId);
     List<DeliveryManager> findAllByTypeOrderBySequenceAsc(DeliveryManagerType type);

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/repository/DeliveryManagerRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/repository/DeliveryManagerRepository.java
@@ -2,8 +2,8 @@ package com.nowayback.delivery.domain.deliverymanager.repository;
 
 import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
 import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
-import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +11,5 @@ public interface DeliveryManagerRepository {
     DeliveryManager save(DeliveryManager deliveryManager);
     Integer findMaxSequenceByType(DeliveryManagerType type);
     Optional<DeliveryManager> findById(UUID deliveryManagerId);
+    List<DeliveryManager> findAllByTypeOrderBySequenceAsc(DeliveryManagerType type);
 }

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/vo/DeliveryManagerType.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/vo/DeliveryManagerType.java
@@ -1,0 +1,13 @@
+package com.nowayback.delivery.domain.deliverymanager.vo;
+
+public enum DeliveryManagerType {
+
+    HUB("허브 배송 관리자"),
+    COMPANY("업체 배송 관리자");
+
+    private final String description;
+
+    DeliveryManagerType(String description) {
+        this.description = description;
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/vo/DeliverySequence.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/vo/DeliverySequence.java
@@ -1,0 +1,29 @@
+package com.nowayback.delivery.domain.deliverymanager.vo;
+
+import com.nowayback.delivery.domain.exception.DeliveryManagerDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryManagerDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliverySequence {
+
+    private int sequence;
+
+    private DeliverySequence(int sequence) {
+        this.sequence = sequence;
+    }
+
+    public static DeliverySequence of(int sequence) {
+        if (sequence < 0) {
+            throw new DeliveryManagerDomainException(DeliveryManagerDomainErrorCode.NEGATIVE_DELIVERY_SEQUENCE_VALUE);
+        }
+        return new DeliverySequence(sequence);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/vo/HubId.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/deliverymanager/vo/HubId.java
@@ -1,0 +1,31 @@
+package com.nowayback.delivery.domain.deliverymanager.vo;
+
+import com.nowayback.delivery.domain.exception.DeliveryManagerDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryManagerDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubId {
+
+    private UUID id;
+
+    private HubId(UUID id) {
+        this.id = id;
+    }
+
+    public static HubId of(UUID id) {
+        if (id == null) {
+            throw new DeliveryManagerDomainException(DeliveryManagerDomainErrorCode.NULL_HUB_ID_VALUE);
+        }
+        return new HubId(id);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryManagerDomainErrorCode.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryManagerDomainErrorCode.java
@@ -1,0 +1,42 @@
+package com.nowayback.delivery.domain.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum DeliveryManagerDomainErrorCode implements ErrorCode {
+    NULL_USER_ID_VALUE("DELIVERYMGR1001", "사용자 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_HUB_ID_VALUE("DELIVERYMGR1002", "허브 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NEGATIVE_DELIVERY_SEQUENCE_VALUE("DELIVERYMGR1003", "배송 시퀀스 값은 음수일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_SLACK_ID_VALUE("DELIVERYMGR1004", "슬랙 ID는 null이거나 공백일 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    NULL_HUB_ID_OBJECT("DELIVERYMGR1005", "허브 ID 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_DELIVERY_MANAGER_TYPE_OBJECT("DELIVERYMGR1006", "배송 관리자 타입 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_DELIVERY_SEQUENCE_OBJECT("DELIVERYMGR1007", "배송 시퀀스 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_DELIVERY_STATUS_OBJECT("DELIVERYMGR1008", "배송 상태 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    DeliveryManagerDomainErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryManagerDomainException.java
+++ b/delivery/src/main/java/com/nowayback/delivery/domain/exception/DeliveryManagerDomainException.java
@@ -1,0 +1,10 @@
+package com.nowayback.delivery.domain.exception;
+
+import com.nowayback.common.exception.GlobalException;
+
+public class DeliveryManagerDomainException extends GlobalException {
+
+    public DeliveryManagerDomainException(DeliveryManagerDomainErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -1,0 +1,17 @@
+package com.nowayback.delivery.infrastructure.repository;
+
+import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryManager, UUID> {
+    @Query("SELECT COALESCE(MAX(dm.deliverySequence.sequence), 0) " +
+            "FROM DeliveryManager dm " +
+            "WHERE dm.type = :type AND dm.deletedAt IS NULL")
+    Integer findMaxSequenceByType(DeliveryManagerType type);
+    Optional<DeliveryManager> findByIdAndDeletedAtIsNull(UUID deliveryManagerId);
+}

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -10,6 +10,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryManager, UUID> {
+
+    boolean existsByIdAndDeletedAtIsNull(UUID userId);
+
     @Query("SELECT COALESCE(MAX(dm.deliverySequence.sequence), 0) " +
             "FROM DeliveryManager dm " +
             "WHERE dm.type = :type AND dm.deletedAt IS NULL")

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -5,6 +5,7 @@ import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,5 +14,12 @@ public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryMana
             "FROM DeliveryManager dm " +
             "WHERE dm.type = :type AND dm.deletedAt IS NULL")
     Integer findMaxSequenceByType(DeliveryManagerType type);
+
     Optional<DeliveryManager> findByIdAndDeletedAtIsNull(UUID deliveryManagerId);
+
+    @Query("SELECT dm " +
+            "FROM DeliveryManager dm " +
+            "WHERE dm.type = :type AND dm.deletedAt IS NULL " +
+            "ORDER BY dm.deliverySequence.sequence ASC")
+    List<DeliveryManager> findAllActiveByTypeOrderBySequenceAsc(DeliveryManagerType type);
 }

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryImpl.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.nowayback.delivery.infrastructure.repository;
+
+import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
+import com.nowayback.delivery.domain.deliverymanager.repository.DeliveryManagerRepository;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryManagerRepositoryImpl implements DeliveryManagerRepository {
+
+    private final DeliveryManagerJpaRepository deliveryManagerJpaRepository;
+
+    @Override
+    public DeliveryManager save(DeliveryManager deliveryManager) {
+        return deliveryManagerJpaRepository.save(deliveryManager);
+    }
+
+    @Override
+    public Integer findMaxSequenceByType(DeliveryManagerType type) {
+        return deliveryManagerJpaRepository.findMaxSequenceByType(type);
+    }
+
+    @Override
+    public Optional<DeliveryManager> findById(UUID deliveryManagerId) {
+        return deliveryManagerJpaRepository.findByIdAndDeletedAtIsNull(deliveryManagerId);
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryImpl.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryImpl.java
@@ -22,6 +22,11 @@ public class DeliveryManagerRepositoryImpl implements DeliveryManagerRepository 
     }
 
     @Override
+    public boolean existsById(UUID userId) {
+        return deliveryManagerJpaRepository.existsByIdAndDeletedAtIsNull(userId);
+    }
+
+    @Override
     public Integer findMaxSequenceByType(DeliveryManagerType type) {
         return deliveryManagerJpaRepository.findMaxSequenceByType(type);
     }

--- a/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryImpl.java
+++ b/delivery/src/main/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,5 +29,10 @@ public class DeliveryManagerRepositoryImpl implements DeliveryManagerRepository 
     @Override
     public Optional<DeliveryManager> findById(UUID deliveryManagerId) {
         return deliveryManagerJpaRepository.findByIdAndDeletedAtIsNull(deliveryManagerId);
+    }
+
+    @Override
+    public List<DeliveryManager> findAllByTypeOrderBySequenceAsc(DeliveryManagerType type) {
+        return deliveryManagerJpaRepository.findAllActiveByTypeOrderBySequenceAsc(type);
     }
 }

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryManagerController.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/DeliveryManagerController.java
@@ -1,0 +1,55 @@
+package com.nowayback.delivery.presentation;
+
+import com.nowayback.common.security.annotation.AuthUser;
+import com.nowayback.common.security.annotation.CurrentUser;
+import com.nowayback.common.security.annotation.RequireRole;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.delivery.application.DeliveryManagerService;
+import com.nowayback.delivery.application.command.CreateDeliveryManagerCommand;
+import com.nowayback.delivery.application.dto.DeliveryManagerResult;
+import com.nowayback.delivery.presentation.dto.request.CreateDeliveryManagerRequest;
+import com.nowayback.delivery.presentation.dto.response.DeliveryManagerResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/delivery-managers")
+@RequiredArgsConstructor
+public class DeliveryManagerController {
+
+    private final DeliveryManagerService deliveryManagerService;
+
+    @PostMapping
+    @RequireRole(UserRole.MASTER)
+    public ResponseEntity<DeliveryManagerResponse> createDeliveryManager(
+            @Valid @RequestBody CreateDeliveryManagerRequest request
+    ) {
+        CreateDeliveryManagerCommand command = CreateDeliveryManagerCommand.of(
+                request.userId(),
+                request.hubId(),
+                request.type()
+        );
+
+        DeliveryManagerResult result = deliveryManagerService.createDeliveryManager(command);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(DeliveryManagerResponse.from(result));
+    }
+
+    @DeleteMapping
+    @RequireRole(UserRole.MASTER)
+    public ResponseEntity<Void> deleteDeliveryManager(
+            @CurrentUser AuthUser authUser,
+            @RequestParam UUID deliveryManagerId
+    ) {
+        deliveryManagerService.deleteDeliveryManager(authUser.userId(), deliveryManagerId);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/dto/request/CreateDeliveryManagerRequest.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/dto/request/CreateDeliveryManagerRequest.java
@@ -1,0 +1,13 @@
+package com.nowayback.delivery.presentation.dto.request;
+
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record CreateDeliveryManagerRequest(
+        @NotNull UUID userId,
+        @NotNull UUID hubId,
+        @NotNull DeliveryManagerType type
+) {
+}

--- a/delivery/src/main/java/com/nowayback/delivery/presentation/dto/response/DeliveryManagerResponse.java
+++ b/delivery/src/main/java/com/nowayback/delivery/presentation/dto/response/DeliveryManagerResponse.java
@@ -1,0 +1,25 @@
+package com.nowayback.delivery.presentation.dto.response;
+
+import com.nowayback.delivery.application.dto.DeliveryManagerResult;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+
+import java.util.UUID;
+
+public record DeliveryManagerResponse(
+        UUID deliveryManagerId,
+        UUID hubId,
+        DeliveryManagerType type,
+        String slackId,
+        int sequence
+) {
+
+    public static DeliveryManagerResponse from(DeliveryManagerResult result) {
+        return new DeliveryManagerResponse(
+                result.deliveryManagerId(),
+                result.hubId(),
+                result.type(),
+                result.slackId(),
+                result.sequence()
+        );
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/application/DeliveryManagerServiceTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/application/DeliveryManagerServiceTest.java
@@ -1,0 +1,199 @@
+package com.nowayback.delivery.application;
+
+import com.nowayback.delivery.application.command.CreateDeliveryManagerCommand;
+import com.nowayback.delivery.application.dto.DeliveryManagerResult;
+import com.nowayback.delivery.application.exception.DeliveryManagerApplicationErrorCode;
+import com.nowayback.delivery.application.exception.DeliveryManagerApplicationException;
+import com.nowayback.delivery.application.service.UserClient;
+import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
+import com.nowayback.delivery.domain.deliverymanager.repository.DeliveryManagerRepository;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.nowayback.delivery.fixture.DeliveryManagerFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("배송 담당자 서비스")
+class DeliveryManagerServiceTest {
+
+    @Mock
+    private DeliveryManagerRepository deliveryManagerRepository;
+
+    @Mock
+    private UserClient userClient;
+
+    @InjectMocks
+    private DeliveryManagerService deliveryManagerService;
+
+    @Nested
+    @DisplayName("배송 담당자 생성")
+    class CreateDeliveryManager {
+
+        @Test
+        @DisplayName("유효한 정보로 배송 담당자를 생성하면 순번이 가장 큰 값 + 1로 생성된다.")
+        void createDeliveryManager_Success() {
+            /* given */
+            CreateDeliveryManagerCommand command = CREATE_DELIVERY_MANAGER_COMMAND;
+            int sequenceBeforeCreate = 2;
+
+            when(deliveryManagerRepository.existsById(any())).thenReturn(false);
+            when(deliveryManagerRepository.findMaxSequenceByType(command.type())).thenReturn(sequenceBeforeCreate);
+            when(userClient.getUserInfoById(command.userId())).thenReturn(USER_INFO);
+            when(deliveryManagerRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            /* when */
+            DeliveryManagerResult result = deliveryManagerService.createDeliveryManager(command);
+
+            /* then */
+            assertThat(result.sequence()).isEqualTo(sequenceBeforeCreate + 1);
+            verify(deliveryManagerRepository, times(1)).save(any());
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 배송 담당자 ID로 생성하려 하면 예외가 발생한다.")
+        void createDeliveryManager_DuplicateId_Exception() {
+            /* given */
+            CreateDeliveryManagerCommand command = CREATE_DELIVERY_MANAGER_COMMAND;
+
+            when(deliveryManagerRepository.existsById(command.userId())).thenReturn(true);
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> deliveryManagerService.createDeliveryManager(command))
+                    .isInstanceOf(DeliveryManagerApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerApplicationErrorCode.DUPLICATE_DELIVERY_MANAGER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 단일 조회")
+    class GetDeliveryManager {
+
+        @Test
+        @DisplayName("존재하는 배송 담당자 ID로 조회하면 배송 담당자 정보를 반환한다.")
+        void getDeliveryManager_Success() {
+            /* given */
+            UUID deliveryManagerId = DELIVERY_MANAGER_UUID;
+            DeliveryManager deliveryManager = createDeliveryManager();
+
+            when(deliveryManagerRepository.findById(deliveryManagerId)).thenReturn(Optional.of(deliveryManager));
+
+            /* when */
+            DeliveryManagerResult result = deliveryManagerService.getDeliveryManager(deliveryManagerId);
+
+            /* then */
+            assertThat(result.deliveryManagerId()).isEqualTo(deliveryManager.getId());
+            verify(deliveryManagerRepository, times(1)).findById(deliveryManagerId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송 담당자 ID로 조회하면 예외가 발생한다.")
+        void getDeliveryManager_NotFound_Exception() {
+            /* given */
+            UUID deliveryManagerId = DELIVERY_MANAGER_UUID;
+
+            when(deliveryManagerRepository.findById(deliveryManagerId)).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> deliveryManagerService.getDeliveryManager(deliveryManagerId))
+                    .isInstanceOf(DeliveryManagerApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerApplicationErrorCode.NOT_FOUND_DELIVERY_MANAGER);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 할당")
+    class AssignDeliveryManager {
+
+        @Test
+        @DisplayName("배송 담당자 유형에 맞는 담당자가 존재하면 라운드로빈 방식으로 배송 담당자를 할당한다.")
+        void assignDeliveryManager_Success() {
+            /* given */
+            DeliveryManagerType type = MANAGER_TYPE;
+
+            when(deliveryManagerRepository.findAllByTypeOrderBySequenceAsc(type))
+                    .thenReturn(DELIVERY_MANAGER_LIST_BY_TYPE);
+
+            /* when */
+            UUID assignedManagerId1 = deliveryManagerService.assignDeliveryManager(type);
+            UUID assignedManagerId2 = deliveryManagerService.assignDeliveryManager(type);
+            UUID assignedManagerId3 = deliveryManagerService.assignDeliveryManager(type);
+            UUID assignedManagerId4 = deliveryManagerService.assignDeliveryManager(type);
+
+            /* then */
+            assertThat(assignedManagerId1).isEqualTo(DELIVERY_MANAGER_LIST_BY_TYPE.get(0).getId());
+            assertThat(assignedManagerId2).isEqualTo(DELIVERY_MANAGER_LIST_BY_TYPE.get(1).getId());
+            assertThat(assignedManagerId3).isEqualTo(DELIVERY_MANAGER_LIST_BY_TYPE.get(2).getId());
+            assertThat(assignedManagerId4).isEqualTo(DELIVERY_MANAGER_LIST_BY_TYPE.get(0).getId());
+        }
+
+        @Test
+        @DisplayName("배송 담당자 유형에 맞는 담당자가 없으면 예외가 발생한다.")
+        void assignDeliveryManager_NotFound_Exception() {
+            /* given */
+            DeliveryManagerType type = MANAGER_TYPE;
+
+            when(deliveryManagerRepository.findAllByTypeOrderBySequenceAsc(type))
+                    .thenReturn(Collections.emptyList());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> deliveryManagerService.assignDeliveryManager(type))
+                    .isInstanceOf(DeliveryManagerApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerApplicationErrorCode.NOT_FOUND_DELIVERY_MANAGER);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 삭제")
+    class DeleteDeliveryManager {
+
+        @Test
+        @DisplayName("유효한 ID로 배송 담당자를 삭제하면 배송 담당자가 삭제된다.")
+        void deleteDeliveryManager_Success() {
+            /* given */
+            UUID actorId = UUID.randomUUID();
+            UUID deliveryManagerId = DELIVERY_MANAGER_UUID;
+
+            DeliveryManager deliveryManager = createDeliveryManager();
+
+            when(deliveryManagerRepository.findById(deliveryManagerId)).thenReturn(Optional.of(deliveryManager));
+
+            /* when */
+            deliveryManagerService.deleteDeliveryManager(actorId, deliveryManagerId);
+
+            /* then */
+            assertThat(deliveryManager.getDeletedAt()).isNotNull();
+            verify(deliveryManagerRepository, times(1)).findById(deliveryManagerId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 배송 담당자를 삭제하려 하면 예외가 발생한다.")
+        void deleteDeliveryManager_NotFound_Exception() {
+            /* given */
+            UUID actorId = UUID.randomUUID();
+            UUID deliveryManagerId = DELIVERY_MANAGER_UUID;
+
+            when(deliveryManagerRepository.findById(deliveryManagerId)).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> deliveryManagerService.deleteDeliveryManager(actorId, deliveryManagerId))
+                    .isInstanceOf(DeliveryManagerApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerApplicationErrorCode.NOT_FOUND_DELIVERY_MANAGER);
+        }
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/domain/deliverymanager/entity/DeliveryManagerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/domain/deliverymanager/entity/DeliveryManagerTest.java
@@ -1,0 +1,133 @@
+package com.nowayback.delivery.domain.deliverymanager.entity;
+
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
+import com.nowayback.delivery.domain.deliverymanager.vo.HubId;
+import com.nowayback.delivery.domain.exception.DeliveryManagerDomainErrorCode;
+import com.nowayback.delivery.domain.exception.DeliveryManagerDomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static com.nowayback.delivery.fixture.DeliveryManagerFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("배송 담당자 엔티티")
+class DeliveryManagerTest {
+
+    @Nested
+    @DisplayName("배송 담당자 생성")
+    class CreateDeliveryManager {
+
+        @Test
+        @DisplayName("모든 필드가 정상일 경우 배송 담당자 생성에 성공한다.")
+        void createDeliveryManager_success () {
+            /* given */
+            UUID deliveryManagerId = DELIVERY_MANAGER_UUID;
+            HubId hubId = HUB_ID;
+            DeliveryManagerType deliveryManagerType = MANAGER_TYPE;
+            String slackId = SLACK_ID;
+            DeliverySequence deliverySequence = DELIVERY_SEQUENCE;
+
+            /* when */
+            DeliveryManager deliveryManager = DeliveryManager.create(
+                    deliveryManagerId,
+                    hubId,
+                    deliveryManagerType,
+                    slackId,
+                    deliverySequence
+            );
+
+            /* then */
+            assertThat(deliveryManager.getId()).isEqualTo(deliveryManagerId);
+            assertThat(deliveryManager.getHubId()).isEqualTo(hubId);
+            assertThat(deliveryManager.getType()).isEqualTo(deliveryManagerType);
+            assertThat(deliveryManager.getSlackId()).isEqualTo(slackId);
+            assertThat(deliveryManager.getDeliverySequence()).isEqualTo(deliverySequence);
+        }
+
+        @Test
+        @DisplayName("배송 담당자 ID는 null일 수 없다.")
+        void createDeliveryManager_WhenIdIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> DeliveryManager.create(null, HUB_ID, MANAGER_TYPE, SLACK_ID, DELIVERY_SEQUENCE))
+                    .isInstanceOf(DeliveryManagerDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerDomainErrorCode.NULL_USER_ID_VALUE);
+        }
+
+        @Test
+        @DisplayName("허브 ID는 null일 수 없다.")
+        void createDeliveryManager_WhenHubIdIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> DeliveryManager.create(DELIVERY_MANAGER_UUID, null, MANAGER_TYPE, SLACK_ID, DELIVERY_SEQUENCE))
+                    .isInstanceOf(DeliveryManagerDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerDomainErrorCode.NULL_HUB_ID_OBJECT);
+        }
+
+        @Test
+        @DisplayName("배송 담당자 타입은 null일 수 없다.")
+        void createDeliveryManager_WhenTypeIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> DeliveryManager.create(DELIVERY_MANAGER_UUID, HUB_ID, null, SLACK_ID, DELIVERY_SEQUENCE))
+                    .isInstanceOf(DeliveryManagerDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerDomainErrorCode.NULL_DELIVERY_MANAGER_TYPE_OBJECT);
+        }
+
+        @Test
+        @DisplayName("슬랙 ID는 null일 수 없다.")
+        void createDeliveryManager_WhenSlackIdIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> DeliveryManager.create(DELIVERY_MANAGER_UUID, HUB_ID, MANAGER_TYPE, null, DELIVERY_SEQUENCE))
+                    .isInstanceOf(DeliveryManagerDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerDomainErrorCode.NULL_SLACK_ID_VALUE);
+        }
+
+        @Test
+        @DisplayName("배송 순서는 null일 수 없다.")
+        void createDeliveryManager_WhenDeliverySequenceIsNull_ShouldThrowException() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> DeliveryManager.create(DELIVERY_MANAGER_UUID, HUB_ID, MANAGER_TYPE, SLACK_ID, null))
+                    .isInstanceOf(DeliveryManagerDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", DeliveryManagerDomainErrorCode.NULL_DELIVERY_SEQUENCE_OBJECT);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 삭제")
+    class DeleteDeliveryManager {
+
+        @Test
+        @DisplayName("삭제 시 소프트 삭제 처리된다.")
+        void deleteDeliveryManager_success() {
+            /* given */
+            DeliveryManager deliveryManager = DeliveryManager.create(
+                    DELIVERY_MANAGER_UUID,
+                    HUB_ID,
+                    MANAGER_TYPE,
+                    SLACK_ID,
+                    DELIVERY_SEQUENCE
+            );
+            UUID deletedBy = UUID.randomUUID();
+
+            /* when */
+            deliveryManager.delete(deletedBy);
+
+            /* then */
+            assertThat(deliveryManager.getDeletedBy()).isEqualTo(deletedBy);
+            assertThat(deliveryManager.getDeletedAt()).isNotNull();
+        }
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryManagerFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryManagerFixture.java
@@ -1,0 +1,22 @@
+package com.nowayback.delivery.fixture;
+
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
+import com.nowayback.delivery.domain.deliverymanager.vo.HubId;
+
+import java.util.UUID;
+
+public class DeliveryManagerFixture {
+
+    public static final UUID DELIVERY_MANAGER_UUID = UUID.randomUUID();
+
+    public static final UUID HUB_UUID = UUID.randomUUID();
+    public static final DeliveryManagerType MANAGER_TYPE = DeliveryManagerType.HUB;
+    public static final String SLACK_ID = "slack_1234";
+    public static final int SEQUENCE = 1;
+
+    public static final HubId HUB_ID = HubId.of(HUB_UUID);
+    public static final DeliverySequence DELIVERY_SEQUENCE = DeliverySequence.of(SEQUENCE);
+
+
+}

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryManagerFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryManagerFixture.java
@@ -1,11 +1,13 @@
 package com.nowayback.delivery.fixture;
 
 import com.nowayback.delivery.application.command.CreateDeliveryManagerCommand;
+import com.nowayback.delivery.application.dto.DeliveryManagerResult;
 import com.nowayback.delivery.application.service.UserClient;
 import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
 import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
 import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
 import com.nowayback.delivery.domain.deliverymanager.vo.HubId;
+import com.nowayback.delivery.presentation.dto.request.CreateDeliveryManagerRequest;
 
 import java.util.List;
 import java.util.UUID;
@@ -59,5 +61,21 @@ public class DeliveryManagerFixture {
     /* user info */
     public static final UserClient.UserInfo USER_INFO = new UserClient.UserInfo(
             SLACK_ID
+    );
+
+    /* delivery manager result */
+    public static final DeliveryManagerResult DELIVERY_MANAGER_RESULT = DeliveryManagerResult.from(createDeliveryManager());
+
+    /* delivery manager request dto */
+    public static final CreateDeliveryManagerRequest CREATE_DELIVERY_MANAGER_REQUEST = new CreateDeliveryManagerRequest(
+            DELIVERY_MANAGER_UUID,
+            HUB_UUID,
+            MANAGER_TYPE
+    );
+
+    public static final CreateDeliveryManagerRequest INVALID_CREATE_DELIVERY_MANAGER_REQUEST = new CreateDeliveryManagerRequest(
+            null,
+            HUB_UUID,
+            MANAGER_TYPE
     );
 }

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryManagerFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryManagerFixture.java
@@ -1,5 +1,6 @@
 package com.nowayback.delivery.fixture;
 
+import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
 import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
 import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
 import com.nowayback.delivery.domain.deliverymanager.vo.HubId;
@@ -18,5 +19,24 @@ public class DeliveryManagerFixture {
     public static final HubId HUB_ID = HubId.of(HUB_UUID);
     public static final DeliverySequence DELIVERY_SEQUENCE = DeliverySequence.of(SEQUENCE);
 
+    /* delivery manager entity */
+    public static DeliveryManager createDeliveryManager() {
+        return DeliveryManager.create(
+                DELIVERY_MANAGER_UUID,
+                HUB_ID,
+                MANAGER_TYPE,
+                SLACK_ID,
+                DELIVERY_SEQUENCE
+        );
+    }
 
+    public static DeliveryManager createDeliveryManager(UUID deliveryManagerId, DeliveryManagerType type, DeliverySequence sequence) {
+        return DeliveryManager.create(
+                deliveryManagerId,
+                HUB_ID,
+                type,
+                SLACK_ID,
+                sequence
+        );
+    }
 }

--- a/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryManagerFixture.java
+++ b/delivery/src/test/java/com/nowayback/delivery/fixture/DeliveryManagerFixture.java
@@ -1,10 +1,13 @@
 package com.nowayback.delivery.fixture;
 
+import com.nowayback.delivery.application.command.CreateDeliveryManagerCommand;
+import com.nowayback.delivery.application.service.UserClient;
 import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
 import com.nowayback.delivery.domain.deliverymanager.vo.DeliveryManagerType;
 import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
 import com.nowayback.delivery.domain.deliverymanager.vo.HubId;
 
+import java.util.List;
 import java.util.UUID;
 
 public class DeliveryManagerFixture {
@@ -39,4 +42,22 @@ public class DeliveryManagerFixture {
                 sequence
         );
     }
+
+    public static final List<DeliveryManager> DELIVERY_MANAGER_LIST_BY_TYPE = List.of(
+            createDeliveryManager(UUID.randomUUID(), MANAGER_TYPE, DeliverySequence.of(1)),
+            createDeliveryManager(UUID.randomUUID(), MANAGER_TYPE, DeliverySequence.of(2)),
+            createDeliveryManager(UUID.randomUUID(), MANAGER_TYPE, DeliverySequence.of(3))
+    );
+
+    /* delivery manager command */
+    public static final CreateDeliveryManagerCommand CREATE_DELIVERY_MANAGER_COMMAND = CreateDeliveryManagerCommand.of(
+            DELIVERY_MANAGER_UUID,
+            HUB_UUID,
+            MANAGER_TYPE
+    );
+
+    /* user info */
+    public static final UserClient.UserInfo USER_INFO = new UserClient.UserInfo(
+            SLACK_ID
+    );
 }

--- a/delivery/src/test/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryTest.java
@@ -1,0 +1,180 @@
+package com.nowayback.delivery.infrastructure.repository;
+
+import com.nowayback.delivery.domain.deliverymanager.entity.DeliveryManager;
+import com.nowayback.delivery.domain.deliverymanager.repository.DeliveryManagerRepository;
+import com.nowayback.delivery.domain.deliverymanager.vo.DeliverySequence;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.nowayback.delivery.fixture.DeliveryManagerFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(DeliveryManagerRepositoryImpl.class)
+@EnableJpaAuditing
+@Testcontainers
+@DisplayName("배송 담당자 리포지토리")
+class DeliveryManagerRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgre = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private DeliveryManagerRepository deliveryManagerRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Nested
+    @DisplayName("배송 담당자 저장")
+    class Save {
+
+        @Test
+        @DisplayName("저장 시 정상적으로 저장된다.")
+        void save_Success() {
+            /* given */
+            DeliveryManager deliveryManager = createDeliveryManager();;
+
+            /* when */
+            DeliveryManager savedDeliveryManager = deliveryManagerRepository.save(deliveryManager);
+
+            /* then */
+            assertThat(savedDeliveryManager.getId()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 타입에 따른 최대 시퀀스 조회")
+    class FindMaxSequenceByType {
+
+        @Test
+        @DisplayName("배송 담당자 타입에 따른 최대 시퀀스를 조회한다.")
+        void findMaxSequenceByType_Success() {
+            /* given */
+            UUID deliveryManagerId1 = UUID.randomUUID();
+            UUID deliveryManagerId2 = UUID.randomUUID();
+
+            DeliverySequence sequence1 = DeliverySequence.of(1);
+            DeliverySequence sequence2 = DeliverySequence.of(2);
+
+            DeliveryManager deliveryManager1 = createDeliveryManager(deliveryManagerId1, MANAGER_TYPE, sequence1);
+            DeliveryManager deliveryManager2 = createDeliveryManager(deliveryManagerId2, MANAGER_TYPE, sequence2);
+
+            entityManager.persist(deliveryManager1);
+            entityManager.persist(deliveryManager2);
+            entityManager.flush();
+
+            /* when */
+            Integer maxSequence = deliveryManagerRepository.findMaxSequenceByType(MANAGER_TYPE);
+
+            /* then */
+            assertThat(maxSequence).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("해당 타입의 배송 담당자가 없는 경우 0을 반환한다.")
+        void findMaxSequenceByType_WhenNoManagers_ReturnsNull() {
+            /* given */
+            /* when */
+            Integer maxSequence = deliveryManagerRepository.findMaxSequenceByType(MANAGER_TYPE);
+
+            /* then */
+            assertThat(maxSequence).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 ID로 배송 담당자 조회")
+    class FindById {
+
+        @Test
+        @DisplayName("배송 담당자 ID로 배송 담당자를 조회한다.")
+        void findById_Success() {
+            /* given */
+            DeliveryManager deliveryManager = createDeliveryManager();
+
+            entityManager.persist(deliveryManager);
+            entityManager.flush();
+
+            /* when */
+            DeliveryManager foundDeliveryManager = deliveryManagerRepository.findById(deliveryManager.getId()).orElseThrow();
+
+            /* then */
+            assertThat(foundDeliveryManager).isNotNull();
+            assertThat(foundDeliveryManager.getId()).isEqualTo(deliveryManager.getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송 담당자 ID로 조회 시 빈 Optional을 반환한다.")
+        void findById_WhenNotExists_ReturnsEmptyOptional() {
+            /* given */
+            /* when */
+            Optional<DeliveryManager> foundDeliveryManager = deliveryManagerRepository.findById(UUID.randomUUID());
+
+            /* then */
+            assertThat(foundDeliveryManager).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 타입에 따른 모든 배송 담당자 조회")
+    class FindAllByTypeOrderBySequenceAsc {
+
+        @Test
+        @DisplayName("배송 담당자 타입에 따른 모든 배송 담당자를 시퀀스 오름차순으로 조회한다.")
+        void findAllByTypeOrderBySequenceAsc_Success() {
+            /* given */
+            UUID deliveryManagerId1 = UUID.randomUUID();
+            UUID deliveryManagerId2 = UUID.randomUUID();
+            UUID deliveryManagerId3 = UUID.randomUUID();
+
+            DeliverySequence sequence1 = DeliverySequence.of(2);
+            DeliverySequence sequence2 = DeliverySequence.of(1);
+            DeliverySequence sequence3 = DeliverySequence.of(3);
+
+            DeliveryManager deliveryManager1 = createDeliveryManager(deliveryManagerId1, MANAGER_TYPE, sequence1);
+            DeliveryManager deliveryManager2 = createDeliveryManager(deliveryManagerId2, MANAGER_TYPE, sequence2);
+            DeliveryManager deletedDeliveryManager = createDeliveryManager(deliveryManagerId3, MANAGER_TYPE, sequence3);
+            deletedDeliveryManager.delete(UUID.randomUUID());
+
+            entityManager.persist(deliveryManager1);
+            entityManager.persist(deliveryManager2);
+            entityManager.persist(deletedDeliveryManager);
+            entityManager.flush();
+
+            /* when */
+            List<DeliveryManager> deliveryManagers = deliveryManagerRepository.findAllByTypeOrderBySequenceAsc(MANAGER_TYPE);
+
+            /* then */
+            assertThat(deliveryManagers).hasSize(2);
+            assertThat(deliveryManagers.get(0).getDeliverySequence().getSequence()).isEqualTo(1);
+            assertThat(deliveryManagers.get(1).getDeliverySequence().getSequence()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("해당 타입의 배송 담당자가 없는 경우 빈 리스트를 반환한다.")
+        void findAllByTypeOrderBySequenceAsc_WhenNoManagers_ReturnsEmptyList() {
+            /* given */
+            /* when */
+            List<DeliveryManager> deliveryManagers = deliveryManagerRepository.findAllByTypeOrderBySequenceAsc(MANAGER_TYPE);
+
+            /* then */
+            assertThat(deliveryManagers).isEmpty();
+        }
+    }
+}

--- a/delivery/src/test/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/infrastructure/repository/DeliveryManagerRepositoryTest.java
@@ -59,6 +59,38 @@ class DeliveryManagerRepositoryTest {
     }
 
     @Nested
+    @DisplayName("배송 담당자 ID에 대한 존재 여부 확인")
+    class ExistsById {
+
+        @Test
+        @DisplayName("존재하는 배송 담당자 ID인 경우 true를 반환한다.")
+        void existsById_WhenExists_ReturnsTrue() {
+            /* given */
+            DeliveryManager deliveryManager = createDeliveryManager();
+
+            entityManager.persist(deliveryManager);
+            entityManager.flush();
+
+            /* when */
+            boolean exists = deliveryManagerRepository.existsById(deliveryManager.getId());
+
+            /* then */
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송 담당자 ID인 경우 false를 반환한다.")
+        void existsById_WhenNotExists_ReturnsFalse() {
+            /* given */
+            /* when */
+            boolean exists = deliveryManagerRepository.existsById(UUID.randomUUID());
+
+            /* then */
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
     @DisplayName("배송 담당자 타입에 따른 최대 시퀀스 조회")
     class FindMaxSequenceByType {
 

--- a/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryManagerControllerTest.java
+++ b/delivery/src/test/java/com/nowayback/delivery/presentation/DeliveryManagerControllerTest.java
@@ -1,0 +1,147 @@
+package com.nowayback.delivery.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.delivery.application.DeliveryManagerService;
+import com.nowayback.delivery.application.dto.DeliveryManagerResult;
+import com.nowayback.delivery.presentation.dto.request.CreateDeliveryManagerRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static com.nowayback.delivery.fixture.DeliveryManagerFixture.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(DeliveryManagerController.class)
+@DisplayName("배송 담당자 컨트롤러")
+class DeliveryManagerControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private DeliveryManagerService deliveryManagerService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final String BASE_URL = "/delivery-managers";
+
+    @Nested
+    @DisplayName("배송 담당자 생성 API")
+    class CreateDeliveryManager {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER"})
+        @DisplayName("유효한 요청이 들어오면 배송 담당자를 생성된다.")
+        void createDeliveryManager_Success(UserRole role) throws Exception {
+            /* given */
+            CreateDeliveryManagerRequest request = CREATE_DELIVERY_MANAGER_REQUEST;;
+            DeliveryManagerResult result = DELIVERY_MANAGER_RESULT;
+
+            given(deliveryManagerService.createDeliveryManager(any())).willReturn(result);
+
+            /* when */
+            /* then */
+            performWithAuth(post(BASE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.deliveryManagerId").value(result.deliveryManagerId().toString()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청이 들어오면 400 에러를 반환한다.")
+        void createDeliveryManager_InvalidRequest_BadRequest() throws Exception {
+            /* given */
+            CreateDeliveryManagerRequest request = INVALID_CREATE_DELIVERY_MANAGER_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(post(BASE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 401 에러를 반환한다.")
+        void createDeliveryManager_WhenHeaderMissing_Unauthorized() throws Exception {
+            /* given */
+            CreateDeliveryManagerRequest request = CREATE_DELIVERY_MANAGER_REQUEST;
+
+            /* when */
+            /* then */
+            mockMvc.perform(post(BASE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"HUB_MANAGER", "DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 403 에러를 반환한다.")
+        void createDeliveryManager_WhenRoleInvalid_Forbidden(UserRole role) throws Exception {
+            /* given */
+            CreateDeliveryManagerRequest request = CREATE_DELIVERY_MANAGER_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(post(BASE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 삭제 API")
+    class DeleteDeliveryManager {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER"})
+        @DisplayName("유효한 요청이 들어오면 배송 담당자를 삭제한다.")
+        void deleteDeliveryManager_Success(UserRole role) throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            performWithAuth(delete(BASE_URL)
+                            .param("deliveryManagerId", DELIVERY_MANAGER_UUID.toString()),
+                    role)
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 401 에러를 반환한다.")
+        void deleteDeliveryManager_WhenHeaderMissing_Unauthorized() throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            mockMvc.perform(delete(BASE_URL)
+                            .param("deliveryManagerId", DELIVERY_MANAGER_UUID.toString()))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"HUB_MANAGER", "DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 403 에러를 반환한다.")
+        void deleteDeliveryManager_WhenRoleInvalid_Forbidden(UserRole role) throws Exception {
+            /* given */
+            /* when */
+            /* then */
+            performWithAuth(delete(BASE_URL)
+                            .param("deliveryManagerId", DELIVERY_MANAGER_UUID.toString()),
+                    role)
+                    .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #50 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
배송 담당자와 관련된 엔티티, 리포지토리, 서비스, 컨트롤러 구현

- 배송 담당자 엔티티
  - `HubId`, `DeliveryManagerType`, `DeliverySequence`로의 VO 분리
  - 배송 담당자 생성 시 각 VO에 대한 null 체크 수행
- 배송 담당자 서비스
  -  `createDeliveryManager` : 배송 담당자 생성
  - `getDeliveryManager` : 배송 담당자 ID를 통한 배송 담당자 단일 조회
  - `assignDeliveryManager` : 배송 담당자 타입을 받아 할당된 배송 담당자의 UUID를 반환
  - `deleteDeliveryManager` : 배송 담당자 ID를 통한 배송 담당자 삭제
- 배송 담당자 컨트롤러
  - 배송 담당자 생성 (`MASTER`만 가능)
  - 배송 담당자 삭제 (`MASTER`만 가능)

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
배송 담당자 엔티티, 리포지토리, 서비스, 컨트롤러에 대한 테스트 코드 확인 부탁드립니다! (모두 통과)

## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
배송 및 배송 경로와 관련된 연쇄 수행 전입니다!
로직이 의도대로 잘 작성되었는지 확인 부탁드립니다~
