### PR TITLE
[#51] 상품 도메인 API 구현

### DIFF
--- a/product/Dockerfile
+++ b/product/Dockerfile
@@ -1,0 +1,31 @@
+### Build Stage ###
+FROM gradle:8.9-jdk17 AS build
+
+WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+COPY common/ common/
+
+COPY product/ product/
+
+RUN gradle clean :product:bootJar -x test --no-daemon
+
+### Runtime Stage ###
+FROM eclipse-temurin:17-jdk-alpine AS runtime
+
+RUN apk update && apk add --no-cache curl
+
+WORKDIR /app
+
+COPY --from=build /app/product/build/libs/*.jar app.jar
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:18086/actuator/health || exit 1
+
+EXPOSE 18086
+
+ENTRYPOINT ["java", \
+    "-Xms512m", \
+    "-Xmx1024m", \
+    "-jar", \
+    "app.jar"]

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -45,6 +45,11 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    /* testcontainers */
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
+
     implementation project(":common")
 }
 

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -38,6 +38,14 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    /* querydsl */
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation project(":common")
 }
 
 dependencyManagement {

--- a/product/docker-compose.local.yml
+++ b/product/docker-compose.local.yml
@@ -1,0 +1,53 @@
+services:
+  product-postgres:
+    image: postgres:15-alpine
+    container_name: product-postgres
+    environment:
+      - POSTGRES_DB=product_db
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=1234
+      - TZ=Asia/Seoul
+    ports:
+      - "5434:5432"
+    volumes:
+      - product-postgres-data:/var/lib/postgresql/data
+    networks:
+      - product-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d product_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  product-service:
+    build:
+      context: ..
+      dockerfile: product/Dockerfile
+      platforms:
+        - linux/amd64
+    image: product-service:latest
+    container_name: product-service
+    environment:
+        - SPRING_PROFILES_ACTIVE=local
+        - PRODUCT_SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5434/product_db
+        - PRODUCT_SPRING_DATASOURCE_USERNAME=user
+        - PRODUCT_SPRING_DATASOURCE_PASSWORD=1234
+    ports:
+      - "18084:18084"
+    depends_on:
+      product-postgres:
+        condition: service_healthy
+    networks:
+      - product-network
+      - msa-network
+    restart: unless-stopped
+
+volumes:
+  product-postgres-data:
+    driver: local
+
+networks:
+  product-network:
+    driver: bridge
+  msa-network:
+    external: true

--- a/product/src/main/java/com/nowayback/product/application/product/ProductService.java
+++ b/product/src/main/java/com/nowayback/product/application/product/ProductService.java
@@ -39,6 +39,8 @@ public class ProductService {
     public void deleteProduct(UUID actorId, UUID productId) {
         Product product = getProductById(productId);
         product.delete(actorId);
+
+        stockService.deleteStock(actorId, productId);
         productRepository.save(product);
     }
 

--- a/product/src/main/java/com/nowayback/product/application/product/ProductService.java
+++ b/product/src/main/java/com/nowayback/product/application/product/ProductService.java
@@ -1,0 +1,49 @@
+package com.nowayback.product.application.product;
+
+import com.nowayback.product.application.product.command.CreateProductCommand;
+import com.nowayback.product.application.product.dto.ProductResult;
+import com.nowayback.product.application.product.exception.ProductApplicationErrorCode;
+import com.nowayback.product.application.product.exception.ProductApplicationException;
+import com.nowayback.product.application.stock.StockService;
+import com.nowayback.product.application.stock.dto.StockResult;
+import com.nowayback.product.domain.product.entity.Product;
+import com.nowayback.product.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final StockService stockService;
+
+    @Transactional
+    public ProductResult createProduct(CreateProductCommand command) {
+        Product product = Product.create(
+                command.supplierId(),
+                command.hubId(),
+                command.productInfo()
+        );
+
+        Product savedProduct = productRepository.save(product);
+        StockResult stockResult = stockService.createStock(savedProduct.getId());
+
+        return ProductResult.from(savedProduct, stockResult.quantity());
+    }
+
+    @Transactional
+    public void deleteProduct(UUID actorId, UUID productId) {
+        Product product = getProductById(productId);
+        product.delete(actorId);
+        productRepository.save(product);
+    }
+
+    private Product getProductById(UUID productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new ProductApplicationException(ProductApplicationErrorCode.NOT_FOUND_PRODUCT));
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/product/command/CreateProductCommand.java
+++ b/product/src/main/java/com/nowayback/product/application/product/command/CreateProductCommand.java
@@ -1,0 +1,27 @@
+package com.nowayback.product.application.product.command;
+
+import com.nowayback.product.domain.product.vo.CompanyId;
+import com.nowayback.product.domain.product.vo.HubId;
+import com.nowayback.product.domain.product.vo.ProductInfo;
+
+import java.util.UUID;
+
+public record CreateProductCommand(
+        CompanyId supplierId,
+        HubId hubId,
+        ProductInfo productInfo
+) {
+
+    public static CreateProductCommand of(
+            UUID supplierId,
+            UUID hubId,
+            String name,
+            int price
+    ) {
+        return new CreateProductCommand(
+                CompanyId.of(supplierId),
+                HubId.of(hubId),
+                ProductInfo.of(name, price)
+        );
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/product/dto/ProductResult.java
+++ b/product/src/main/java/com/nowayback/product/application/product/dto/ProductResult.java
@@ -1,0 +1,26 @@
+package com.nowayback.product.application.product.dto;
+
+import com.nowayback.product.domain.product.entity.Product;
+
+import java.util.UUID;
+
+public record ProductResult(
+        UUID productId,
+        UUID supplierId,
+        UUID hubId,
+        String name,
+        int price,
+        int quantity
+) {
+
+    public static ProductResult from(Product product, int quantity) {
+        return new ProductResult(
+                product.getId(),
+                product.getSupplierId().getId(),
+                product.getHubId().getId(),
+                product.getProductInfo().getName(),
+                product.getProductInfo().getPrice(),
+                quantity
+        );
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/product/exception/ProductApplicationErrorCode.java
+++ b/product/src/main/java/com/nowayback/product/application/product/exception/ProductApplicationErrorCode.java
@@ -1,0 +1,34 @@
+package com.nowayback.product.application.product.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ProductApplicationErrorCode implements ErrorCode {
+    NOT_FOUND_PRODUCT("PRODUCT2001", "해당 상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ProductApplicationErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/product/exception/ProductApplicationException.java
+++ b/product/src/main/java/com/nowayback/product/application/product/exception/ProductApplicationException.java
@@ -1,0 +1,11 @@
+package com.nowayback.product.application.product.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import com.nowayback.common.exception.GlobalException;
+
+public class ProductApplicationException extends GlobalException {
+
+    public ProductApplicationException(ProductApplicationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/stock/StockService.java
+++ b/product/src/main/java/com/nowayback/product/application/stock/StockService.java
@@ -1,5 +1,7 @@
 package com.nowayback.product.application.stock;
 
+import com.nowayback.product.application.stock.command.DecreaseStockCommand;
+import com.nowayback.product.application.stock.command.IncreaseStockCommand;
 import com.nowayback.product.application.stock.dto.StockResult;
 import com.nowayback.product.application.stock.exception.StockApplicationErrorCode;
 import com.nowayback.product.application.stock.exception.StockApplicationException;
@@ -33,22 +35,22 @@ public class StockService {
     }
 
     @Transactional
-    public StockResult increaseStock(UUID productId, int amount) {
-        Stock stock = getStockByProductId(ProductId.of(productId));
+    public StockResult increaseStock(IncreaseStockCommand command) {
+        Stock stock = getStockByProductId(command.productId());
         Quantity quantity = stock.getQuantity();
 
-        Quantity increasedQuantity = quantity.add(Quantity.of(amount));
+        Quantity increasedQuantity = quantity.add(command.amount());
         stock.updateQuantity(increasedQuantity);
 
         return StockResult.from(stock);
     }
 
     @Transactional
-    public StockResult decreaseStock(UUID productId, int amount) {
-        Stock stock = getStockByProductId(ProductId.of(productId));
+    public StockResult decreaseStock(DecreaseStockCommand command) {
+        Stock stock = getStockByProductId(command.productId());
         Quantity quantity = stock.getQuantity();
 
-        Quantity decreasedQuantity = quantity.subtract(Quantity.of(amount));
+        Quantity decreasedQuantity = quantity.subtract(command.amount());
         stock.updateQuantity(decreasedQuantity);
 
         return StockResult.from(stock);

--- a/product/src/main/java/com/nowayback/product/application/stock/StockService.java
+++ b/product/src/main/java/com/nowayback/product/application/stock/StockService.java
@@ -1,0 +1,73 @@
+package com.nowayback.product.application.stock;
+
+import com.nowayback.product.application.stock.dto.StockResult;
+import com.nowayback.product.application.stock.exception.StockApplicationErrorCode;
+import com.nowayback.product.application.stock.exception.StockApplicationException;
+import com.nowayback.product.domain.stock.entity.Stock;
+import com.nowayback.product.domain.stock.repository.StockRepository;
+import com.nowayback.product.domain.stock.vo.ProductId;
+import com.nowayback.product.domain.stock.vo.Quantity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StockService {
+
+    private final StockRepository stockRepository;
+
+    public StockResult createStock(UUID productId) {
+        validateDuplicateProductId(productId);
+
+        Stock stock = Stock.create(ProductId.of(productId));
+        Stock savedStock = stockRepository.save(stock);
+        return StockResult.from(savedStock);
+    }
+
+    public StockResult getStock(UUID productId) {
+        Stock stock = getStockByProductId(ProductId.of(productId));
+        return StockResult.from(stock);
+    }
+
+    @Transactional
+    public StockResult increaseStock(UUID productId, int amount) {
+        Stock stock = getStockByProductId(ProductId.of(productId));
+        Quantity quantity = stock.getQuantity();
+
+        Quantity increasedQuantity = quantity.add(Quantity.of(amount));
+        stock.updateQuantity(increasedQuantity);
+
+        return StockResult.from(stock);
+    }
+
+    @Transactional
+    public StockResult decreaseStock(UUID productId, int amount) {
+        Stock stock = getStockByProductId(ProductId.of(productId));
+        Quantity quantity = stock.getQuantity();
+
+        Quantity decreasedQuantity = quantity.subtract(Quantity.of(amount));
+        stock.updateQuantity(decreasedQuantity);
+
+        return StockResult.from(stock);
+    }
+
+    public void deleteStock(UUID actorId, UUID productId) {
+        Stock stock = getStockByProductId(ProductId.of(productId));
+        stock.delete(actorId);
+        stockRepository.save(stock);
+    }
+
+    private Stock getStockByProductId(ProductId productId) {
+        return stockRepository.findByProductId(productId)
+                .orElseThrow(() -> new StockApplicationException(StockApplicationErrorCode.NOT_FOUND_STOCK));
+    }
+
+    private void validateDuplicateProductId(UUID productId) {
+        if (stockRepository.existsByProductId(ProductId.of(productId))) {
+            throw new StockApplicationException(StockApplicationErrorCode.DUPLICATE_PRODUCT_ID);
+        }
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/stock/command/DecreaseStockCommand.java
+++ b/product/src/main/java/com/nowayback/product/application/stock/command/DecreaseStockCommand.java
@@ -1,0 +1,22 @@
+package com.nowayback.product.application.stock.command;
+
+import com.nowayback.product.domain.stock.vo.ProductId;
+import com.nowayback.product.domain.stock.vo.Quantity;
+
+import java.util.UUID;
+
+public record DecreaseStockCommand (
+        ProductId productId,
+        Quantity amount
+) {
+
+    public static DecreaseStockCommand of(
+            UUID productId,
+            int amount
+    ) {
+        return new DecreaseStockCommand(
+                ProductId.of(productId),
+                Quantity.of(amount)
+        );
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/stock/command/IncreaseStockCommand.java
+++ b/product/src/main/java/com/nowayback/product/application/stock/command/IncreaseStockCommand.java
@@ -1,0 +1,22 @@
+package com.nowayback.product.application.stock.command;
+
+import com.nowayback.product.domain.stock.vo.ProductId;
+import com.nowayback.product.domain.stock.vo.Quantity;
+
+import java.util.UUID;
+
+public record IncreaseStockCommand(
+        ProductId productId,
+        Quantity amount
+) {
+
+    public static IncreaseStockCommand of(
+            UUID productId,
+            int amount
+    ) {
+        return new IncreaseStockCommand(
+                ProductId.of(productId),
+                Quantity.of(amount)
+        );
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/stock/dto/StockResult.java
+++ b/product/src/main/java/com/nowayback/product/application/stock/dto/StockResult.java
@@ -1,0 +1,17 @@
+package com.nowayback.product.application.stock.dto;
+
+import com.nowayback.product.domain.stock.entity.Stock;
+
+import java.util.UUID;
+
+public record StockResult(
+        UUID productId,
+        int quantity
+) {
+    public static StockResult from(Stock stock) {
+        return new StockResult(
+                stock.getProductId().getId(),
+                stock.getQuantity().getQuantity()
+        );
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/stock/exception/StockApplicationErrorCode.java
+++ b/product/src/main/java/com/nowayback/product/application/stock/exception/StockApplicationErrorCode.java
@@ -1,0 +1,35 @@
+package com.nowayback.product.application.stock.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum StockApplicationErrorCode implements ErrorCode {
+    NOT_FOUND_STOCK("STOCK2001", "상품에 대한 재고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DUPLICATE_PRODUCT_ID("STOCK2002", "해당 상품에 대한 재고가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    StockApplicationErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/product/src/main/java/com/nowayback/product/application/stock/exception/StockApplicationException.java
+++ b/product/src/main/java/com/nowayback/product/application/stock/exception/StockApplicationException.java
@@ -1,0 +1,11 @@
+package com.nowayback.product.application.stock.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import com.nowayback.common.exception.GlobalException;
+
+public class StockApplicationException extends GlobalException {
+
+    public StockApplicationException(StockApplicationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/product/entity/Product.java
+++ b/product/src/main/java/com/nowayback/product/domain/product/entity/Product.java
@@ -1,0 +1,74 @@
+package com.nowayback.product.domain.product.entity;
+
+import com.nowayback.common.audit.BaseEntity;
+import com.nowayback.product.domain.product.exception.ProductDomainErrorCode;
+import com.nowayback.product.domain.product.exception.ProductDomainException;
+import com.nowayback.product.domain.product.vo.CompanyId;
+import com.nowayback.product.domain.product.vo.HubId;
+import com.nowayback.product.domain.product.vo.ProductInfo;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_products")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "product_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "supplier_id", nullable = false))
+    private CompanyId supplierId;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "hub_id", nullable = false))
+    private HubId hubId;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "name", column = @Column(name = "name", nullable = false)),
+            @AttributeOverride(name = "price", column = @Column(name = "price", nullable = false)),
+    })
+    private ProductInfo productInfo;
+
+    public Product(CompanyId supplierId, HubId hubId, ProductInfo productInfo) {
+        this.supplierId = supplierId;
+        this.hubId = hubId;
+        this.productInfo = productInfo;
+    }
+
+    public static Product create(CompanyId supplierId, HubId hubId, ProductInfo productInfo) {
+        validateCompanyId(supplierId);
+        validateHubId(hubId);
+        validateProductInfo(productInfo);
+
+        return new Product(supplierId, hubId, productInfo);
+    }
+
+    public void delete(UUID deletedBy) {
+        softDelete(deletedBy);
+    }
+
+    private static void validateNotNull(Object object, ProductDomainErrorCode errorCode) {
+        if (object == null) throw new ProductDomainException(errorCode);
+    }
+
+    public static void validateCompanyId(CompanyId supplierId) {
+        validateNotNull(supplierId, ProductDomainErrorCode.NULL_SUPPLIER_ID_OBJECT);
+    }
+
+    public static void validateHubId(HubId hubId) {
+        validateNotNull(hubId, ProductDomainErrorCode.NULL_HUB_ID_OBJECT);
+    }
+
+    public static void validateProductInfo(ProductInfo productInfo) {
+        validateNotNull(productInfo, ProductDomainErrorCode.NULL_PRODUCT_INFO_OBJECT);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/product/exception/ProductDomainErrorCode.java
+++ b/product/src/main/java/com/nowayback/product/domain/product/exception/ProductDomainErrorCode.java
@@ -1,0 +1,42 @@
+package com.nowayback.product.domain.product.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ProductDomainErrorCode implements ErrorCode {
+
+    NULL_COMPANY_ID_VALUE("PRODUCT1001", "업체 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_HUB_ID_VALUE("PRODUCT1002", "허브 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PRODUCT_NAME("PRODUCT1003", "상품 이름이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    NEGATIVE_PRODUCT_PRICE("PRODUCT1004", "상품 가격은 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+
+    NULL_SUPPLIER_ID_OBJECT("PRODUCT1005", "공급업체 ID 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_HUB_ID_OBJECT("PRODUCT1006", "허브 ID 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_PRODUCT_INFO_OBJECT("PRODUCT1007", "상품 정보는 null일 수 없습니다.", HttpStatus.BAD_REQUEST)
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ProductDomainErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/product/exception/ProductDomainException.java
+++ b/product/src/main/java/com/nowayback/product/domain/product/exception/ProductDomainException.java
@@ -1,0 +1,10 @@
+package com.nowayback.product.domain.product.exception;
+
+import com.nowayback.common.exception.GlobalException;
+
+public class ProductDomainException extends GlobalException {
+
+    public ProductDomainException(ProductDomainErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/product/repository/ProductRepository.java
+++ b/product/src/main/java/com/nowayback/product/domain/product/repository/ProductRepository.java
@@ -1,0 +1,11 @@
+package com.nowayback.product.domain.product.repository;
+
+import com.nowayback.product.domain.product.entity.Product;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProductRepository {
+    Product save(Product product);
+    Optional<Product> findById(UUID productId);
+}

--- a/product/src/main/java/com/nowayback/product/domain/product/vo/CompanyId.java
+++ b/product/src/main/java/com/nowayback/product/domain/product/vo/CompanyId.java
@@ -1,0 +1,31 @@
+package com.nowayback.product.domain.product.vo;
+
+import com.nowayback.product.domain.product.exception.ProductDomainErrorCode;
+import com.nowayback.product.domain.product.exception.ProductDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyId {
+
+    private UUID id;
+
+    private CompanyId(UUID id) {
+        this.id = id;
+    }
+
+    public static CompanyId of(UUID id) {
+        if (id == null) {
+            throw new ProductDomainException(ProductDomainErrorCode.NULL_COMPANY_ID_VALUE);
+        }
+        return new CompanyId(id);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/product/vo/HubId.java
+++ b/product/src/main/java/com/nowayback/product/domain/product/vo/HubId.java
@@ -1,0 +1,31 @@
+package com.nowayback.product.domain.product.vo;
+
+import com.nowayback.product.domain.product.exception.ProductDomainErrorCode;
+import com.nowayback.product.domain.product.exception.ProductDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubId {
+
+    private UUID id;
+
+    private HubId(UUID id) {
+        this.id = id;
+    }
+
+    public static HubId of(UUID id) {
+        if (id == null) {
+            throw new ProductDomainException(ProductDomainErrorCode.NULL_HUB_ID_VALUE);
+        }
+        return new HubId(id);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/product/vo/ProductInfo.java
+++ b/product/src/main/java/com/nowayback/product/domain/product/vo/ProductInfo.java
@@ -1,0 +1,43 @@
+package com.nowayback.product.domain.product.vo;
+
+import com.nowayback.product.domain.product.exception.ProductDomainErrorCode;
+import com.nowayback.product.domain.product.exception.ProductDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductInfo {
+
+    private String name;
+    private int price;
+
+    private ProductInfo(String name, int price) {
+        this.name = name;
+        this.price = price;
+    }
+
+    public static ProductInfo of(String name, int price) {
+        validateName(name);
+        validatePrice(price);
+
+        return new ProductInfo(name, price);
+    }
+
+    private static void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new ProductDomainException(ProductDomainErrorCode.INVALID_PRODUCT_NAME);
+        }
+    }
+
+    private static void validatePrice(int price) {
+        if (price < 0) {
+            throw new ProductDomainException(ProductDomainErrorCode.NEGATIVE_PRODUCT_PRICE);
+        }
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/stock/entity/Stock.java
+++ b/product/src/main/java/com/nowayback/product/domain/stock/entity/Stock.java
@@ -1,0 +1,60 @@
+package com.nowayback.product.domain.stock.entity;
+
+import com.nowayback.common.audit.BaseEntity;
+import com.nowayback.product.domain.stock.exception.StockDomainErrorCode;
+import com.nowayback.product.domain.stock.exception.StockDomainException;
+import com.nowayback.product.domain.stock.vo.ProductId;
+import com.nowayback.product.domain.stock.vo.Quantity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_stocks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stock extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "stock_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "product_id", updatable = false, nullable = false))
+    private ProductId productId;
+
+    @Embedded
+    @AttributeOverride(name = "quantity", column = @Column(name = "quantity", nullable = false))
+    private Quantity quantity;
+
+    public Stock(ProductId productId, Quantity quantity) {
+        this.productId = productId;
+        this.quantity = quantity;
+    }
+
+    public static Stock create(ProductId productId) {
+        validateProductId(productId);
+
+        return new Stock(productId, Quantity.zero());
+    }
+
+    public void updateQuantity(Quantity newQuantity) {
+        validateNotNull(newQuantity, StockDomainErrorCode.NULL_QUANTITY_OBJECT);
+        this.quantity = newQuantity;
+    }
+
+    public void delete(UUID deletedBy) {
+        softDelete(deletedBy);
+    }
+
+    private static void validateNotNull(Object object, StockDomainErrorCode errorCode) {
+        if (object == null) throw new StockDomainException(errorCode);
+    }
+
+    private static void validateProductId(ProductId productId) {
+        validateNotNull(productId, StockDomainErrorCode.NULL_PRODUCT_ID_OBJECT);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/stock/exception/StockDomainErrorCode.java
+++ b/product/src/main/java/com/nowayback/product/domain/stock/exception/StockDomainErrorCode.java
@@ -1,0 +1,39 @@
+package com.nowayback.product.domain.stock.exception;
+
+import com.nowayback.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum StockDomainErrorCode implements ErrorCode {
+    NULL_PRODUCT_ID_VALUE("STOCK1001", "상품 ID는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NEGATIVE_STOCK_QUANTITY("STOCK1002", "재고 수량은 음수일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INSUFFICIENT_STOCK_QUANTITY("STOCK1003", "재고 수량이 부족합니다.", HttpStatus.BAD_REQUEST),
+
+    NULL_PRODUCT_ID_OBJECT("STOCK1004", "상품 ID 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NULL_QUANTITY_OBJECT("STOCK1005", "재고 수량 객체는 null일 수 없습니다.", HttpStatus.BAD_REQUEST)
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    StockDomainErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/stock/exception/StockDomainException.java
+++ b/product/src/main/java/com/nowayback/product/domain/stock/exception/StockDomainException.java
@@ -1,0 +1,10 @@
+package com.nowayback.product.domain.stock.exception;
+
+import com.nowayback.common.exception.GlobalException;
+
+public class StockDomainException extends GlobalException {
+
+    public StockDomainException(StockDomainErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/stock/repository/StockRepository.java
+++ b/product/src/main/java/com/nowayback/product/domain/stock/repository/StockRepository.java
@@ -1,0 +1,12 @@
+package com.nowayback.product.domain.stock.repository;
+
+import com.nowayback.product.domain.stock.entity.Stock;
+import com.nowayback.product.domain.stock.vo.ProductId;
+
+import java.util.Optional;
+
+public interface StockRepository {
+    Stock save(Stock stock);
+    boolean existsByProductId(ProductId productId);
+    Optional<Stock> findByProductId(ProductId productId);
+}

--- a/product/src/main/java/com/nowayback/product/domain/stock/vo/ProductId.java
+++ b/product/src/main/java/com/nowayback/product/domain/stock/vo/ProductId.java
@@ -1,0 +1,31 @@
+package com.nowayback.product.domain.stock.vo;
+
+import com.nowayback.product.domain.stock.exception.StockDomainErrorCode;
+import com.nowayback.product.domain.stock.exception.StockDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductId {
+
+    private UUID id;
+
+    private ProductId(UUID id) {
+        this.id = id;
+    }
+
+    public static ProductId of(UUID id) {
+        if (id == null) {
+            throw new StockDomainException(StockDomainErrorCode.NULL_PRODUCT_ID_VALUE);
+        }
+        return new ProductId(id);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/stock/vo/Quantity.java
+++ b/product/src/main/java/com/nowayback/product/domain/stock/vo/Quantity.java
@@ -1,0 +1,61 @@
+package com.nowayback.product.domain.stock.vo;
+
+import com.nowayback.product.domain.stock.exception.StockDomainErrorCode;
+import com.nowayback.product.domain.stock.exception.StockDomainException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Quantity {
+
+    private int quantity;
+
+    private Quantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public static Quantity of(int quantity) {
+        validateQuantity(quantity);
+
+        return new Quantity(quantity);
+    }
+
+    public static Quantity zero() {
+        return new Quantity(0);
+    }
+
+    public Quantity add(Quantity other) {
+        validateQuantityObject(other);
+
+        return new Quantity(this.quantity + other.quantity);
+    }
+
+    public Quantity subtract(Quantity other) {
+        validateQuantityObject(other);
+
+        int resultQuantity = this.quantity - other.quantity;
+        if (resultQuantity < 0) {
+            throw new StockDomainException(StockDomainErrorCode.INSUFFICIENT_STOCK_QUANTITY);
+        }
+
+        return new Quantity(resultQuantity);
+    }
+
+    private static void validateQuantity(int quantity) {
+        if (quantity < 0) {
+            throw new StockDomainException(StockDomainErrorCode.INSUFFICIENT_STOCK_QUANTITY);
+        }
+    }
+
+    private static void validateQuantityObject(Quantity quantity) {
+        if (quantity == null) {
+            throw new StockDomainException(StockDomainErrorCode.NULL_QUANTITY_OBJECT);
+        }
+    }
+}

--- a/product/src/main/java/com/nowayback/product/domain/stock/vo/Quantity.java
+++ b/product/src/main/java/com/nowayback/product/domain/stock/vo/Quantity.java
@@ -49,7 +49,7 @@ public class Quantity {
 
     private static void validateQuantity(int quantity) {
         if (quantity < 0) {
-            throw new StockDomainException(StockDomainErrorCode.INSUFFICIENT_STOCK_QUANTITY);
+            throw new StockDomainException(StockDomainErrorCode.NEGATIVE_STOCK_QUANTITY);
         }
     }
 

--- a/product/src/main/java/com/nowayback/product/infrastructure/product/repository/ProductJpaRepository.java
+++ b/product/src/main/java/com/nowayback/product/infrastructure/product/repository/ProductJpaRepository.java
@@ -1,0 +1,11 @@
+package com.nowayback.product.infrastructure.product.repository;
+
+import com.nowayback.product.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
+    Optional<Product> findByIdAndDeletedAtIsNull(UUID productId);
+}

--- a/product/src/main/java/com/nowayback/product/infrastructure/product/repository/ProductRepositoryImpl.java
+++ b/product/src/main/java/com/nowayback/product/infrastructure/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.nowayback.product.infrastructure.product.repository;
+
+import com.nowayback.product.domain.product.entity.Product;
+import com.nowayback.product.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final ProductJpaRepository productJpaRepository;
+
+    @Override
+    public Product save(Product product) {
+        return productJpaRepository.save(product);
+    }
+
+    @Override
+    public Optional<Product> findById(UUID productId) {
+        return productJpaRepository.findByIdAndDeletedAtIsNull(productId);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/infrastructure/stock/repository/StockJpaRepository.java
+++ b/product/src/main/java/com/nowayback/product/infrastructure/stock/repository/StockJpaRepository.java
@@ -1,0 +1,13 @@
+package com.nowayback.product.infrastructure.stock.repository;
+
+import com.nowayback.product.domain.stock.entity.Stock;
+import com.nowayback.product.domain.stock.vo.ProductId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface StockJpaRepository extends JpaRepository<Stock, UUID> {
+    boolean existsByProductIdAndDeletedAtIsNull(ProductId productId);
+    Optional<Stock> findByProductIdAndDeletedAtIsNull(ProductId productId);
+}

--- a/product/src/main/java/com/nowayback/product/infrastructure/stock/repository/StockRepositoryImpl.java
+++ b/product/src/main/java/com/nowayback/product/infrastructure/stock/repository/StockRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.nowayback.product.infrastructure.stock.repository;
+
+import com.nowayback.product.domain.stock.entity.Stock;
+import com.nowayback.product.domain.stock.repository.StockRepository;
+import com.nowayback.product.domain.stock.vo.ProductId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class StockRepositoryImpl implements StockRepository {
+
+    private final StockJpaRepository stockJpaRepository;
+
+    @Override
+    public Stock save(Stock stock) {
+        return stockJpaRepository.save(stock);
+    }
+
+    @Override
+    public boolean existsByProductId(ProductId productId) {
+        return stockJpaRepository.existsByProductIdAndDeletedAtIsNull(productId);
+    }
+
+    @Override
+    public Optional<Stock> findByProductId(ProductId productId) {
+        return stockJpaRepository.findByProductIdAndDeletedAtIsNull(productId);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/presentation/product/ProductController.java
+++ b/product/src/main/java/com/nowayback/product/presentation/product/ProductController.java
@@ -1,0 +1,52 @@
+package com.nowayback.product.presentation.product;
+
+import com.nowayback.common.security.annotation.CurrentUser;
+import com.nowayback.common.security.annotation.RequireRole;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.product.application.product.ProductService;
+import com.nowayback.product.application.product.command.CreateProductCommand;
+import com.nowayback.product.presentation.product.dto.request.CreateProductRequest;
+import com.nowayback.product.presentation.product.dto.response.ProductResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @PostMapping
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER})
+    public ResponseEntity<ProductResponse> createProduct(
+            @Valid @RequestBody CreateProductRequest request
+    ) {
+        CreateProductCommand command = CreateProductCommand.of(
+                request.supplierId(),
+                request.hubId(),
+                request.name(),
+                request.price()
+        );
+
+        ProductResponse response = ProductResponse.from(productService.createProduct(command));
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    @DeleteMapping("/{productId}")
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER})
+    public ResponseEntity<Void> deleteProduct(
+            @CurrentUser UUID userId,
+            @PathVariable("productId") UUID productId
+    ) {
+        productService.deleteProduct(userId, productId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/product/src/main/java/com/nowayback/product/presentation/product/dto/request/CreateProductRequest.java
+++ b/product/src/main/java/com/nowayback/product/presentation/product/dto/request/CreateProductRequest.java
@@ -1,0 +1,14 @@
+package com.nowayback.product.presentation.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record CreateProductRequest(
+        @NotNull UUID supplierId,
+        @NotNull UUID hubId,
+        @NotBlank String name,
+        int price
+) {
+}

--- a/product/src/main/java/com/nowayback/product/presentation/product/dto/response/ProductResponse.java
+++ b/product/src/main/java/com/nowayback/product/presentation/product/dto/response/ProductResponse.java
@@ -1,0 +1,25 @@
+package com.nowayback.product.presentation.product.dto.response;
+
+import com.nowayback.product.application.product.dto.ProductResult;
+
+import java.util.UUID;
+
+public record ProductResponse(
+        UUID productId,
+        UUID supplierId,
+        UUID hubId,
+        String name,
+        int price,
+        int quantity
+) {
+    public static ProductResponse from(ProductResult result) {
+        return new ProductResponse(
+                result.productId(),
+                result.supplierId(),
+                result.hubId(),
+                result.name(),
+                result.price(),
+                result.quantity()
+        );
+    }
+}

--- a/product/src/main/java/com/nowayback/product/presentation/stock/StockController.java
+++ b/product/src/main/java/com/nowayback/product/presentation/stock/StockController.java
@@ -1,0 +1,54 @@
+package com.nowayback.product.presentation.stock;
+
+import com.nowayback.common.security.annotation.RequireRole;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.product.application.stock.StockService;
+import com.nowayback.product.application.stock.command.DecreaseStockCommand;
+import com.nowayback.product.application.stock.command.IncreaseStockCommand;
+import com.nowayback.product.presentation.stock.dto.request.DecreaseStockRequest;
+import com.nowayback.product.presentation.stock.dto.request.IncreaseStockRequest;
+import com.nowayback.product.presentation.stock.dto.response.StockResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/stocks")
+@RequiredArgsConstructor
+public class StockController {
+
+    private final StockService stockService;
+
+    @PatchMapping("/{productId}/increase")
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER})
+    public ResponseEntity<StockResponse> increaseStock(
+            @PathVariable UUID productId,
+            @Valid @RequestBody IncreaseStockRequest request
+    ) {
+        IncreaseStockCommand command = IncreaseStockCommand.of(
+                productId,
+                request.amount()
+        );
+
+        StockResponse response = StockResponse.from(stockService.increaseStock(command));
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{productId}/decrease")
+    @RequireRole({UserRole.MASTER, UserRole.HUB_MANAGER})
+    public ResponseEntity<StockResponse> decreaseStock(
+            @PathVariable UUID productId,
+            @Valid @RequestBody DecreaseStockRequest request
+    ) {
+        DecreaseStockCommand command = DecreaseStockCommand.of(
+                productId,
+                request.amount()
+        );
+
+        StockResponse response = StockResponse.from(stockService.decreaseStock(command));
+        return ResponseEntity.ok(response);
+    }
+}

--- a/product/src/main/java/com/nowayback/product/presentation/stock/dto/request/DecreaseStockRequest.java
+++ b/product/src/main/java/com/nowayback/product/presentation/stock/dto/request/DecreaseStockRequest.java
@@ -1,0 +1,8 @@
+package com.nowayback.product.presentation.stock.dto.request;
+
+import jakarta.validation.constraints.Positive;
+
+public record DecreaseStockRequest(
+        @Positive int amount
+) {
+}

--- a/product/src/main/java/com/nowayback/product/presentation/stock/dto/request/IncreaseStockRequest.java
+++ b/product/src/main/java/com/nowayback/product/presentation/stock/dto/request/IncreaseStockRequest.java
@@ -1,0 +1,8 @@
+package com.nowayback.product.presentation.stock.dto.request;
+
+import jakarta.validation.constraints.Positive;
+
+public record IncreaseStockRequest(
+        @Positive int amount
+) {
+}

--- a/product/src/main/java/com/nowayback/product/presentation/stock/dto/response/StockResponse.java
+++ b/product/src/main/java/com/nowayback/product/presentation/stock/dto/response/StockResponse.java
@@ -1,0 +1,18 @@
+package com.nowayback.product.presentation.stock.dto.response;
+
+import com.nowayback.product.application.stock.dto.StockResult;
+
+import java.util.UUID;
+
+public record StockResponse(
+        UUID productId,
+        int quantity
+) {
+
+    public static StockResponse from(StockResult result) {
+        return new StockResponse(
+                result.productId(),
+                result.quantity()
+        );
+    }
+}

--- a/product/src/main/resources/application-local.yaml
+++ b/product/src/main/resources/application-local.yaml
@@ -1,0 +1,19 @@
+server:
+  port: 18084
+
+spring:
+  datasource:
+    url: ${PRODUCT_SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5434/product_db}
+    username: ${PRODUCT_SPRING_DATASOURCE_USERNAME:user}
+    password: ${PRODUCT_SPRING_DATASOURCE_PASSWORD:1234}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        default_schema: product_service
+    show_sql: true

--- a/product/src/main/resources/application-prod.yaml
+++ b/product/src/main/resources/application-prod.yaml
@@ -1,0 +1,19 @@
+server:
+  port: 18084
+
+spring:
+  datasource:
+    url: ${PRODUCT_SPRING_DATASOURCE_URL}
+    username: ${PRODUCT_SPRING_DATASOURCE_USERNAME}
+    password: ${PRODUCT_SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        default_schema: product_service
+    show_sql: true

--- a/product/src/main/resources/application.yaml
+++ b/product/src/main/resources/application.yaml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: product
+  profiles:
+    active: local

--- a/product/src/test/java/com/nowayback/product/application/product/ProductServiceTest.java
+++ b/product/src/test/java/com/nowayback/product/application/product/ProductServiceTest.java
@@ -83,7 +83,9 @@ class ProductServiceTest {
 
             /* then */
             assertThat(product.isDeleted()).isTrue();
+
             verify(productRepository).save(any());
+            verify(stockService).deleteStock(actorId, productId);
         }
 
         @Test

--- a/product/src/test/java/com/nowayback/product/application/product/ProductServiceTest.java
+++ b/product/src/test/java/com/nowayback/product/application/product/ProductServiceTest.java
@@ -1,0 +1,105 @@
+package com.nowayback.product.application.product;
+
+import com.nowayback.product.application.product.command.CreateProductCommand;
+import com.nowayback.product.application.product.dto.ProductResult;
+import com.nowayback.product.application.product.exception.ProductApplicationErrorCode;
+import com.nowayback.product.application.product.exception.ProductApplicationException;
+import com.nowayback.product.application.stock.StockService;
+import com.nowayback.product.domain.product.entity.Product;
+import com.nowayback.product.domain.product.repository.ProductRepository;
+import com.nowayback.product.fixture.StockFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.nowayback.product.fixture.ProductFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("상품 서비스 테스트")
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private StockService stockService;
+
+    @InjectMocks
+    private ProductService productService;
+
+    @Nested
+    @DisplayName("상품 생성")
+    class CreateProduct {
+
+        @Test
+        @DisplayName("정상적으로 상품이 생성된다.")
+        void createProduct_Success() {
+            /* given */
+            CreateProductCommand command = CREATE_PRODUCT_COMMAND;
+
+            when(productRepository.save(any())).thenReturn(createProduct());
+            when(stockService.createStock(any())).thenReturn(StockFixture.STOCK_RESULT);
+
+            /* when */
+            ProductResult result = productService.createProduct(command);
+
+            /* then */
+            assertThat(result.supplierId()).isEqualTo(SUPPLIER_UUID);
+            assertThat(result.hubId()).isEqualTo(HUB_UUID);
+            assertThat(result.name()).isEqualTo(NAME);
+            assertThat(result.price()).isEqualTo(PRICE);
+            assertThat(result.quantity()).isZero();
+
+            verify(productRepository).save(any());
+            verify(stockService).createStock(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 삭제")
+    class DeleteProduct {
+
+        @Test
+        @DisplayName("정상적으로 상품이 삭제된다.")
+        void deleteProduct_Success() {
+            /* given */
+            UUID actorId = UUID.randomUUID();
+            UUID productId = PRODUCT_ID;
+            Product product = createProduct();
+
+            when(productRepository.findById(any())).thenReturn(Optional.of(product));
+
+            /* when */
+            productService.deleteProduct(actorId, productId);
+
+            /* then */
+            assertThat(product.isDeleted()).isTrue();
+            verify(productRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품을 삭제하려고 하면 예외가 발생한다.")
+        void deleteProduct_NotFoundProduct_Exception() {
+            /* given */
+            UUID actorId = UUID.randomUUID();
+            UUID productId = PRODUCT_ID;
+
+            when(productRepository.findById(any())).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> productService.deleteProduct(actorId, productId))
+                    .isInstanceOf(ProductApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ProductApplicationErrorCode.NOT_FOUND_PRODUCT);
+        }
+    }
+}

--- a/product/src/test/java/com/nowayback/product/application/stock/StockServiceTest.java
+++ b/product/src/test/java/com/nowayback/product/application/stock/StockServiceTest.java
@@ -1,0 +1,237 @@
+package com.nowayback.product.application.stock;
+
+import com.nowayback.product.application.stock.command.DecreaseStockCommand;
+import com.nowayback.product.application.stock.command.IncreaseStockCommand;
+import com.nowayback.product.application.stock.dto.StockResult;
+import com.nowayback.product.application.stock.exception.StockApplicationErrorCode;
+import com.nowayback.product.application.stock.exception.StockApplicationException;
+import com.nowayback.product.domain.stock.entity.Stock;
+import com.nowayback.product.domain.stock.exception.StockDomainErrorCode;
+import com.nowayback.product.domain.stock.exception.StockDomainException;
+import com.nowayback.product.domain.stock.repository.StockRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.nowayback.product.fixture.StockFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StockServiceTest {
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @InjectMocks
+    private StockService stockService;
+
+    @Nested
+    @DisplayName("재고 생성")
+    class CreateStock {
+
+        @Test
+        @DisplayName("정상적으로 재고가 생성된다.")
+        void createStock_Success() {
+            /* given */
+            UUID productId = PRODUCT_UUID;
+
+            when(stockRepository.existsByProductId(any())).thenReturn(false);
+            when(stockRepository.save(any())).thenReturn(createStock());
+
+            /* when */
+            StockResult result = stockService.createStock(productId);
+
+            /* then */
+            assertThat(result.productId()).isEqualTo(productId);
+            assertThat(result.quantity()).isZero();
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 상품에 대해 재고를 생성하려고 하면 예외가 발생한다.")
+        void createStock_DuplicateProductId_Exception() {
+            /* given */
+            UUID productId = PRODUCT_UUID;
+
+            when(stockRepository.existsByProductId(any())).thenReturn(true);
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> stockService.createStock(productId))
+                    .isInstanceOf(StockApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", StockApplicationErrorCode.DUPLICATE_PRODUCT_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("재고 조회")
+    class GetStock {
+
+        @Test
+        @DisplayName("정상적으로 재고가 조회된다.")
+        void getStock_Success() {
+            /* given */
+            Stock stock = createStock();
+            UUID productId = PRODUCT_UUID;
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.of(stock));
+
+            /* when */
+            StockResult result = stockService.getStock(productId);
+
+            /* then */
+            assertThat(result.productId()).isEqualTo(productId);
+            assertThat(result.quantity()).isZero();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재고를 조회하려고 하면 예외가 발생한다.")
+        void getStock_NotFoundStock_Exception() {
+            /* given */
+            UUID productId = PRODUCT_UUID;
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> stockService.getStock(productId))
+                    .isInstanceOf(StockApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", StockApplicationErrorCode.NOT_FOUND_STOCK);
+        }
+    }
+
+    @Nested
+    @DisplayName("재고 증가")
+    class IncreaseStock {
+
+        @Test
+        @DisplayName("정상적으로 재고가 증가된다.")
+        void increaseStock_Success() {
+            /* given */
+            IncreaseStockCommand command = INCREASE_STOCK_COMMAND;
+            Stock stock = createStock();
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.of(stock));
+
+            /* when */
+            StockResult result = stockService.increaseStock(command);
+
+            /* then */
+            assertThat(result.productId()).isEqualTo(command.productId().getId());
+            assertThat(result.quantity()).isEqualTo(command.amount().getQuantity());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재고에 대해 재고 증가를 시도하면 예외가 발생한다.")
+        void increaseStock_NotFoundStock_Exception() {
+            /* given */
+            IncreaseStockCommand command = INCREASE_STOCK_COMMAND;
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> stockService.increaseStock(command))
+                    .isInstanceOf(StockApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", StockApplicationErrorCode.NOT_FOUND_STOCK);
+        }
+    }
+
+    @Nested
+    @DisplayName("재고 차감")
+    class DecreaseStock {
+
+        @Test
+        @DisplayName("정상적으로 재고가 차감된다.")
+        void decreaseStock_Success() {
+            /* given */
+            DecreaseStockCommand command = DECREASE_STOCK_COMMAND;
+            Stock stock = createStock(QUANTITY);
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.of(stock));
+
+            /* when */
+            StockResult result = stockService.decreaseStock(command);
+
+            /* then */
+            assertThat(result.productId()).isEqualTo(command.productId().getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재고에 대해 재고 차감을 시도하면 예외가 발생한다.")
+        void decreaseStock_NotFoundStock_Exception() {
+            /* given */
+            DecreaseStockCommand command = DECREASE_STOCK_COMMAND;
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> stockService.decreaseStock(command))
+                    .isInstanceOf(StockApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", StockApplicationErrorCode.NOT_FOUND_STOCK);
+        }
+
+        @Test
+        @DisplayName("재고보다 많은 양을 차감하려고 하면 예외가 발생한다.")
+        void decreaseStock_InsufficientStock_Exception() {
+            /* given */
+            DecreaseStockCommand command = INSUFFICIENT_DECREASE_STOCK_COMMAND;
+            Stock stock = createStock(QUANTITY);
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.of(stock));
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> stockService.decreaseStock(command))
+                    .isInstanceOf(StockDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", StockDomainErrorCode.INSUFFICIENT_STOCK_QUANTITY);
+        }
+    }
+
+    @Nested
+    @DisplayName("재고 삭제")
+    class DeleteStock {
+
+        @Test
+        @DisplayName("정상적으로 재고가 삭제된다.")
+        void deleteStock_Success() {
+            /* given */
+            UUID actorId = UUID.randomUUID();
+            UUID productId = PRODUCT_UUID;
+            Stock stock = createStock();
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.of(stock));
+
+            /* when */
+            stockService.deleteStock(actorId, productId);
+
+            /* then */
+            assertThat(stock.isDeleted()).isTrue();
+            verify(stockRepository).save(any(Stock.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재고에 대해 재고 삭제를 시도하면 예외가 발생한다.")
+        void deleteStock_NotFoundStock_Exception() {
+            /* given */
+            UUID actorId = UUID.randomUUID();
+            UUID productId = PRODUCT_UUID;
+
+            when(stockRepository.findByProductId(any())).thenReturn(Optional.empty());
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> stockService.deleteStock(actorId, productId))
+                    .isInstanceOf(StockApplicationException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", StockApplicationErrorCode.NOT_FOUND_STOCK);
+        }
+    }
+}

--- a/product/src/test/java/com/nowayback/product/domain/product/entity/ProductTest.java
+++ b/product/src/test/java/com/nowayback/product/domain/product/entity/ProductTest.java
@@ -1,0 +1,99 @@
+package com.nowayback.product.domain.product.entity;
+
+import com.nowayback.product.domain.product.exception.ProductDomainErrorCode;
+import com.nowayback.product.domain.product.exception.ProductDomainException;
+import com.nowayback.product.domain.product.vo.CompanyId;
+import com.nowayback.product.domain.product.vo.HubId;
+import com.nowayback.product.domain.product.vo.ProductInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static com.nowayback.product.fixture.ProductFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("상품 엔티티 테스트")
+class ProductTest {
+
+    @Nested
+    @DisplayName("상품 생성")
+    class CreateProduct {
+
+        @Test
+        @DisplayName("모든 필드가 정상일 경우 상품 생성에 성공한다.")
+        void createProduct_Success() {
+            /* given */
+            CompanyId supplierId = SUPPLIER_ID;
+            HubId hubId = HUB_ID;
+            ProductInfo productInfo = PRODUCT_INFO;
+
+            /* when */
+            Product product = Product.create(
+                    supplierId,
+                    hubId,
+                    productInfo
+            );
+
+            /* then */
+            assertThat(product.getSupplierId()).isEqualTo(supplierId);
+            assertThat(product.getHubId()).isEqualTo(hubId);
+            assertThat(product.getProductInfo()).isEqualTo(productInfo);
+        }
+
+        @Test
+        @DisplayName("공급업체 ID는 null일 수 없다.")
+        void createProduct_SupplierIdNull_Failure() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> Product.create(null, HUB_ID, PRODUCT_INFO))
+                    .isInstanceOf(ProductDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ProductDomainErrorCode.NULL_SUPPLIER_ID_OBJECT);
+        }
+
+        @Test
+        @DisplayName("허브 ID는 null일 수 없다.")
+        void createProduct_HubIdNull_Failure() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> Product.create(SUPPLIER_ID, null, PRODUCT_INFO))
+                    .isInstanceOf(ProductDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ProductDomainErrorCode.NULL_HUB_ID_OBJECT);
+        }
+
+        @Test
+        @DisplayName("상품 정보는 null일 수 없다.")
+        void createProduct_ProductInfoNull_Failure() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> Product.create(SUPPLIER_ID, HUB_ID, null))
+                    .isInstanceOf(ProductDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ProductDomainErrorCode.NULL_PRODUCT_INFO_OBJECT);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 삭제")
+    class DeleteProduct {
+
+        @Test
+        @DisplayName("정상적인 상품 삭제에 성공한다.")
+        void deleteProduct_Success() {
+            /* given */
+            Product product = createProduct();
+            UUID deletedBy = UUID.randomUUID();
+
+            /* when */
+            product.delete(deletedBy);
+
+            /* then */
+            assertThat(product.isDeleted()).isTrue();
+            assertThat(product.getDeletedBy()).isEqualTo(deletedBy);
+        }
+    }
+}

--- a/product/src/test/java/com/nowayback/product/domain/stock/entity/StockTest.java
+++ b/product/src/test/java/com/nowayback/product/domain/stock/entity/StockTest.java
@@ -1,0 +1,100 @@
+package com.nowayback.product.domain.stock.entity;
+
+import com.nowayback.product.domain.stock.exception.StockDomainErrorCode;
+import com.nowayback.product.domain.stock.exception.StockDomainException;
+import com.nowayback.product.domain.stock.vo.ProductId;
+import com.nowayback.product.domain.stock.vo.Quantity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static com.nowayback.product.fixture.StockFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("재고 엔티티 테스트")
+class StockTest {
+
+    @Nested
+    @DisplayName("재고 생성")
+    class CreateStock {
+
+        @Test
+        @DisplayName("모든 필드가 정상일 경우 재고 생성에 성공한다.")
+        void createStock_Success() {
+            /* given */
+            ProductId productId = PRODUCT_ID;
+
+            /* when */
+            Stock stock = Stock.create(productId);
+
+            /* then */
+            assertThat(stock.getProductId()).isEqualTo(productId);
+        }
+
+        @Test
+        @DisplayName("상품 ID는 null일 수 없다.")
+        void createStock_ProductIdNull_Failure() {
+            /* given */
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> Stock.create(null))
+                    .isInstanceOf(StockDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", StockDomainErrorCode.NULL_PRODUCT_ID_OBJECT);
+        }
+    }
+
+    @Nested
+    @DisplayName("재고 수량 수정")
+    class UpdateQuantity {
+
+        @Test
+        @DisplayName("정상적인 수량으로 재고 수량 수정에 성공한다.")
+        void updateQuantity_Success() {
+            /* given */
+            Stock stock = createStock();
+            Quantity newQuantity = QUANTITY;
+
+            /* when */
+            stock.updateQuantity(newQuantity);
+
+            /* then */
+            assertThat(stock.getQuantity()).isEqualTo(newQuantity);
+        }
+
+        @Test
+        @DisplayName("수량은 null일 수 없다.")
+        void updateQuantity_QuantityNull_Failure() {
+            /* given */
+            Stock stock = createStock();
+
+            /* when */
+            /* then */
+            assertThatThrownBy(() -> stock.updateQuantity(null))
+                    .isInstanceOf(StockDomainException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", StockDomainErrorCode.NULL_QUANTITY_OBJECT);
+        }
+    }
+
+    @Nested
+    @DisplayName("재고 삭제")
+    class DeleteStock {
+
+        @Test
+        @DisplayName("정상적인 재고 삭제에 성공한다.")
+        void deleteStock_Success() {
+            /* given */
+            Stock stock = createStock();
+            UUID actorId = UUID.randomUUID();
+
+            /* when */
+            stock.delete(actorId);
+
+            /* then */
+            assertThat(stock.isDeleted()).isTrue();
+            assertThat(stock.getDeletedBy()).isEqualTo(actorId);
+        }
+    }
+}

--- a/product/src/test/java/com/nowayback/product/fixture/ProductFixture.java
+++ b/product/src/test/java/com/nowayback/product/fixture/ProductFixture.java
@@ -1,5 +1,6 @@
 package com.nowayback.product.fixture;
 
+import com.nowayback.product.application.product.command.CreateProductCommand;
 import com.nowayback.product.domain.product.entity.Product;
 import com.nowayback.product.domain.product.vo.CompanyId;
 import com.nowayback.product.domain.product.vo.HubId;
@@ -28,4 +29,12 @@ public class ProductFixture {
                 PRODUCT_INFO
         );
     }
+
+    /* product command */
+    public static final CreateProductCommand CREATE_PRODUCT_COMMAND = CreateProductCommand.of(
+            SUPPLIER_UUID,
+            HUB_UUID,
+            NAME,
+            PRICE
+    );
 }

--- a/product/src/test/java/com/nowayback/product/fixture/ProductFixture.java
+++ b/product/src/test/java/com/nowayback/product/fixture/ProductFixture.java
@@ -1,0 +1,31 @@
+package com.nowayback.product.fixture;
+
+import com.nowayback.product.domain.product.entity.Product;
+import com.nowayback.product.domain.product.vo.CompanyId;
+import com.nowayback.product.domain.product.vo.HubId;
+import com.nowayback.product.domain.product.vo.ProductInfo;
+
+import java.util.UUID;
+
+public class ProductFixture {
+
+    public static final UUID PRODUCT_ID = UUID.randomUUID();
+
+    public static final UUID SUPPLIER_UUID = UUID.randomUUID();
+    public static final UUID HUB_UUID = UUID.randomUUID();
+    public static final String NAME = "Sample Product";
+    public static final int PRICE = 12_000;
+
+    public static final CompanyId SUPPLIER_ID = CompanyId.of(SUPPLIER_UUID);
+    public static final HubId HUB_ID = HubId.of(HUB_UUID);
+    public static final ProductInfo PRODUCT_INFO = ProductInfo.of(NAME, PRICE);
+
+    /* product entity */
+    public static Product createProduct() {
+        return Product.create(
+                SUPPLIER_ID,
+                HUB_ID,
+                PRODUCT_INFO
+        );
+    }
+}

--- a/product/src/test/java/com/nowayback/product/fixture/ProductFixture.java
+++ b/product/src/test/java/com/nowayback/product/fixture/ProductFixture.java
@@ -1,10 +1,12 @@
 package com.nowayback.product.fixture;
 
 import com.nowayback.product.application.product.command.CreateProductCommand;
+import com.nowayback.product.application.product.dto.ProductResult;
 import com.nowayback.product.domain.product.entity.Product;
 import com.nowayback.product.domain.product.vo.CompanyId;
 import com.nowayback.product.domain.product.vo.HubId;
 import com.nowayback.product.domain.product.vo.ProductInfo;
+import com.nowayback.product.presentation.product.dto.request.CreateProductRequest;
 
 import java.util.UUID;
 
@@ -16,6 +18,7 @@ public class ProductFixture {
     public static final UUID HUB_UUID = UUID.randomUUID();
     public static final String NAME = "Sample Product";
     public static final int PRICE = 12_000;
+    public static final int QUANTITY = 0;
 
     public static final CompanyId SUPPLIER_ID = CompanyId.of(SUPPLIER_UUID);
     public static final HubId HUB_ID = HubId.of(HUB_UUID);
@@ -35,6 +38,24 @@ public class ProductFixture {
             SUPPLIER_UUID,
             HUB_UUID,
             NAME,
+            PRICE
+    );
+
+    /* product result */
+    public static final ProductResult PRODUCT_RESULT = ProductResult.from(createProduct(), QUANTITY);
+
+    /* product request */
+    public static final CreateProductRequest VALID_CREATE_PRODUCT_REQUEST = new CreateProductRequest(
+            SUPPLIER_UUID,
+            HUB_UUID,
+            NAME,
+            PRICE
+    );
+
+    public static final CreateProductRequest INVALID_CREATE_PRODUCT_REQUEST = new CreateProductRequest(
+            null,
+            null,
+            "",
             PRICE
     );
 }

--- a/product/src/test/java/com/nowayback/product/fixture/StockFixture.java
+++ b/product/src/test/java/com/nowayback/product/fixture/StockFixture.java
@@ -2,9 +2,12 @@ package com.nowayback.product.fixture;
 
 import com.nowayback.product.application.stock.command.DecreaseStockCommand;
 import com.nowayback.product.application.stock.command.IncreaseStockCommand;
+import com.nowayback.product.application.stock.dto.StockResult;
 import com.nowayback.product.domain.stock.entity.Stock;
 import com.nowayback.product.domain.stock.vo.ProductId;
 import com.nowayback.product.domain.stock.vo.Quantity;
+import com.nowayback.product.presentation.stock.dto.request.DecreaseStockRequest;
+import com.nowayback.product.presentation.stock.dto.request.IncreaseStockRequest;
 
 import java.util.UUID;
 
@@ -44,4 +47,14 @@ public class StockFixture {
             PRODUCT_UUID,
             QUANTITY_VALUE + 10
     );
+
+    /* stock result */
+    public static final StockResult STOCK_RESULT = StockResult.from(createStock());
+
+    /* stock request */
+    public static final IncreaseStockRequest VALID_INCREASE_STOCK_REQUEST = new IncreaseStockRequest(QUANTITY_VALUE);
+    public static final IncreaseStockRequest INVALID_INCREASE_STOCK_REQUEST = new IncreaseStockRequest(-10);
+
+    public static final DecreaseStockRequest VALID_DECREASE_STOCK_REQUEST = new DecreaseStockRequest(QUANTITY_VALUE);
+    public static final DecreaseStockRequest INVALID_DECREASE_STOCK_REQUEST = new DecreaseStockRequest(-10);
 }

--- a/product/src/test/java/com/nowayback/product/fixture/StockFixture.java
+++ b/product/src/test/java/com/nowayback/product/fixture/StockFixture.java
@@ -1,0 +1,29 @@
+package com.nowayback.product.fixture;
+
+import com.nowayback.product.domain.stock.entity.Stock;
+import com.nowayback.product.domain.stock.vo.ProductId;
+import com.nowayback.product.domain.stock.vo.Quantity;
+
+import java.util.UUID;
+
+public class StockFixture {
+
+    public static final UUID STOCK_ID = UUID.randomUUID();
+
+    public static final UUID PRODUCT_UUID = UUID.randomUUID();
+    public static final int QUANTITY_VALUE = 100;
+
+    public static final ProductId PRODUCT_ID = ProductId.of(PRODUCT_UUID);
+    public static final Quantity QUANTITY = Quantity.of(QUANTITY_VALUE);
+
+    /* stock entity */
+    public static Stock createStock() {
+        return Stock.create(PRODUCT_ID);
+    }
+
+    public static Stock createStock(Quantity quantity) {
+        Stock stock = createStock();
+        stock.updateQuantity(quantity);
+        return stock;
+    }
+}

--- a/product/src/test/java/com/nowayback/product/fixture/StockFixture.java
+++ b/product/src/test/java/com/nowayback/product/fixture/StockFixture.java
@@ -1,5 +1,7 @@
 package com.nowayback.product.fixture;
 
+import com.nowayback.product.application.stock.command.DecreaseStockCommand;
+import com.nowayback.product.application.stock.command.IncreaseStockCommand;
 import com.nowayback.product.domain.stock.entity.Stock;
 import com.nowayback.product.domain.stock.vo.ProductId;
 import com.nowayback.product.domain.stock.vo.Quantity;
@@ -26,4 +28,20 @@ public class StockFixture {
         stock.updateQuantity(quantity);
         return stock;
     }
+
+    /* stock command */
+    public static final IncreaseStockCommand INCREASE_STOCK_COMMAND = IncreaseStockCommand.of(
+            PRODUCT_UUID,
+            QUANTITY_VALUE
+    );
+
+    public static final DecreaseStockCommand DECREASE_STOCK_COMMAND = DecreaseStockCommand.of(
+            PRODUCT_UUID,
+            QUANTITY_VALUE
+    );
+
+    public static final DecreaseStockCommand INSUFFICIENT_DECREASE_STOCK_COMMAND = DecreaseStockCommand.of(
+            PRODUCT_UUID,
+            QUANTITY_VALUE + 10
+    );
 }

--- a/product/src/test/java/com/nowayback/product/infrastructure/product/repository/ProductRepositoryTest.java
+++ b/product/src/test/java/com/nowayback/product/infrastructure/product/repository/ProductRepositoryTest.java
@@ -1,0 +1,110 @@
+package com.nowayback.product.infrastructure.product.repository;
+
+import com.nowayback.product.domain.product.entity.Product;
+import com.nowayback.product.domain.product.repository.ProductRepository;
+import com.nowayback.product.infrastructure.stock.repository.StockRepositoryImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.nowayback.product.fixture.ProductFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(ProductRepositoryImpl.class)
+@EnableJpaAuditing
+@Testcontainers
+@DisplayName("상품 리포지토리 테스트")
+class ProductRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgre = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Nested
+    @DisplayName("상품 저장")
+    class Save {
+
+        @Test
+        @DisplayName("정상적으로 상품이 저장된다.")
+        void save_Success() {
+            /* given */
+            Product product = createProduct();
+
+            /* when */
+            Product savedProduct = productRepository.save(product);
+
+            /* then */
+            assertThat(savedProduct.getId()).isNotNull();
+        }
+    }
+
+
+    @Nested
+    @DisplayName("상품 ID로 상품 조회")
+    class FindById {
+
+        @Test
+        @DisplayName("존재하는 상품 ID로 조회하면 상품을 반환한다.")
+        void findById_ExistingProductId_Success() {
+            /* given */
+            Product product = createProduct();
+
+            entityManager.persist(product);
+            entityManager.flush();
+
+            /* when */
+            Optional<Product> foundProduct = productRepository.findById(product.getId());
+
+            /* then */
+            assertThat(foundProduct).isPresent();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품 ID로 조회하면 빈 Optional을 반환한다.")
+        void findById_NonExistingProductId_ShouldReturnEmptyOptional() {
+            /* given */
+            /* when */
+            Optional<Product> foundProduct = productRepository.findById(PRODUCT_ID);
+
+            /* then */
+            assertThat(foundProduct).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("상품 ID에 대한 상품이 삭제된 경우 빈 Optional을 반환한다.")
+        void findById_DeletedProductId_ShouldReturnEmptyOptional() {
+            /* given */
+            UUID deletedBy = UUID.randomUUID();
+            Product product = createProduct();
+            product.delete(deletedBy);
+
+            entityManager.persist(product);
+            entityManager.flush();
+
+            /* when */
+            Optional<Product> foundProduct = productRepository.findById(product.getId());
+
+            /* then */
+            assertThat(foundProduct).isNotPresent();
+        }
+    }
+}

--- a/product/src/test/java/com/nowayback/product/infrastructure/stock/repository/StockRepositoryTest.java
+++ b/product/src/test/java/com/nowayback/product/infrastructure/stock/repository/StockRepositoryTest.java
@@ -1,0 +1,140 @@
+package com.nowayback.product.infrastructure.stock.repository;
+
+import com.nowayback.product.domain.stock.entity.Stock;
+import com.nowayback.product.domain.stock.repository.StockRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.nowayback.product.fixture.StockFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(StockRepositoryImpl.class)
+@EnableJpaAuditing
+@Testcontainers
+@DisplayName("재고 리포지토리 테스트")
+class StockRepositoryTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgre = new PostgreSQLContainer<>("postgres:15");
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Nested
+    @DisplayName("재고 저장")
+    class Save {
+
+        @Test
+        @DisplayName("정상적으로 재고가 저장된다.")
+        void save_Success() {
+            /* given */
+            Stock stock = createStock();
+
+            /* when */
+            Stock savedStock = stockRepository.save(stock);
+
+            /* then */
+            assertThat(savedStock.getId()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 ID로 재고 존재 여부 확인")
+    class ExistsByProductId {
+
+        @Test
+        @DisplayName("상품 ID에 대한 재고가 존재하면 true를 반환한다.")
+        void existsByProductId_Exists_ShouldReturnTrue() {
+            /* given */
+            Stock stock = createStock();
+
+            entityManager.persist(stock);
+            entityManager.flush();
+
+            /* when */
+            boolean exists = stockRepository.existsByProductId(stock.getProductId());
+
+            /* then */
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("상품 ID에 대한 재고가 존재하지 않으면 false를 반환한다.")
+        void existsByProductId_NotExists_ShouldReturnFalse() {
+            /* given */
+            /* when */
+            boolean exists = stockRepository.existsByProductId(PRODUCT_ID);
+
+            /* then */
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 아이디로 재고 조회")
+    class FindByProductId {
+
+        @Test
+        @DisplayName("상품 ID에 대한 재고가 존재하면 재고를 반환한다.")
+        void findByProductId_Exists_ShouldReturnStock() {
+            /* given */
+            Stock stock = createStock();
+
+            entityManager.persist(stock);
+            entityManager.flush();
+
+            /* when */
+            Optional<Stock> foundStock = stockRepository.findByProductId(stock.getProductId());
+
+            /* then */
+            assertThat(foundStock).isPresent();
+        }
+
+        @Test
+        @DisplayName("상품 ID에 대한 재고가 존재하지 않으면 빈 Optional을 반환한다.")
+        void findByProductId_NotExists_ShouldReturnEmptyOptional() {
+            /* given */
+            /* when */
+            Optional<Stock> foundStock = stockRepository.findByProductId(PRODUCT_ID);
+
+            /* then */
+            assertThat(foundStock).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("상품 ID에 대한 재고가 삭제된 경우 빈 Optional을 반환한다.")
+        void findByProductId_Deleted_ShouldReturnEmptyOptional() {
+            /* given */
+            UUID deletedBy = UUID.randomUUID();
+            Stock stock = createStock();
+            stock.delete(deletedBy);
+
+            entityManager.persist(stock);
+            entityManager.flush();
+
+            /* when */
+            Optional<Stock> foundStock = stockRepository.findByProductId(stock.getProductId());
+
+            /* then */
+            assertThat(foundStock).isNotPresent();
+        }
+    }
+}

--- a/product/src/test/java/com/nowayback/product/presentation/ControllerTest.java
+++ b/product/src/test/java/com/nowayback/product/presentation/ControllerTest.java
@@ -1,0 +1,39 @@
+package com.nowayback.product.presentation;
+
+import com.nowayback.common.exception.GlobalExceptionHandler;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.common.security.config.CommonWebConfig;
+import com.nowayback.common.security.interceptor.JwtConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.UUID;
+
+@Import({
+        CommonWebConfig.class,
+        GlobalExceptionHandler.class
+})
+public abstract class ControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    protected ResultActions performWithAuth(MockHttpServletRequestBuilder builder, UserRole role) throws Exception {
+        UUID userId = UUID.randomUUID();
+        String username = "test";
+
+        return mockMvc.perform(
+                builder
+                        .header(JwtConstants.HEADER_USER_ID, userId.toString())
+                        .header(JwtConstants.HEADER_USERNAME, username)
+                        .header(JwtConstants.HEADER_ROLE, role.name())
+        );
+    }
+
+    protected ResultActions performWithAuth(MockHttpServletRequestBuilder builder) throws Exception {
+        return performWithAuth(builder, UserRole.MASTER);
+    }
+}

--- a/product/src/test/java/com/nowayback/product/presentation/product/ProductControllerTest.java
+++ b/product/src/test/java/com/nowayback/product/presentation/product/ProductControllerTest.java
@@ -1,0 +1,154 @@
+package com.nowayback.product.presentation.product;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.product.application.product.ProductService;
+import com.nowayback.product.application.product.dto.ProductResult;
+import com.nowayback.product.presentation.ControllerTest;
+import com.nowayback.product.presentation.product.dto.request.CreateProductRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.UUID;
+
+import static com.nowayback.product.fixture.ProductFixture.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(ProductController.class)
+@DisplayName("상품 컨트롤러 테스트")
+class ProductControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private ProductService productService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final String BASE_UTL = "/products";
+
+    @Nested
+    @DisplayName("상품 생성 API")
+    class CreateProduct {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER"})
+        @DisplayName("유효한 요청이 들어오면 상품이 정상적으로 생성된다.")
+        void createProduct_Success(UserRole role) throws Exception {
+            /* given */
+            CreateProductRequest request= VALID_CREATE_PRODUCT_REQUEST;
+            ProductResult result = PRODUCT_RESULT;
+
+            given(productService.createProduct(any())).willReturn(result);
+
+            /* when */
+            /* then */
+            performWithAuth(post(BASE_UTL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.supplierId").value(result.supplierId().toString()))
+                    .andExpect(jsonPath("$.hubId").value(result.hubId().toString()))
+                    .andExpect(jsonPath("$.name").value(result.name()))
+                    .andExpect(jsonPath("$.price").value(result.price()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청이 들어오면 응답코드 400을 반환한다.")
+        void createProduct_InvalidRequest_Failure() throws Exception {
+            /* given */
+            CreateProductRequest request= INVALID_CREATE_PRODUCT_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(post(BASE_UTL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void createProduct_UnauthenticatedUser_Unauthorized() throws Exception {
+            /* given */
+            CreateProductRequest request= VALID_CREATE_PRODUCT_REQUEST;
+
+            /* when */
+            /* then */
+            mockMvc.perform(post(BASE_UTL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void createProduct_ForbiddenUser_Forbidden(UserRole role) throws Exception {
+            /* given */
+            CreateProductRequest request= VALID_CREATE_PRODUCT_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(post(BASE_UTL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 삭제 API")
+    class DeleteProduct {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER"})
+        @DisplayName("유효한 요청이 들어오면 상품이 정상적으로 삭제된다.")
+        void deleteProduct_Success(UserRole role) throws Exception {
+            /* given */
+            UUID productId = PRODUCT_ID;
+
+            /* when */
+            /* then */
+            performWithAuth(delete(BASE_UTL + "/{productId}", productId), role)
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void deleteProduct_UnauthenticatedUser_Unauthorized() throws Exception {
+            /* given */
+            UUID productId = PRODUCT_ID;
+
+            /* when */
+            /* then */
+            mockMvc.perform(delete(BASE_UTL + "/{productId}", productId))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void deleteProduct_ForbiddenUser_Forbidden(UserRole role) throws Exception {
+            /* given */
+            UUID productId = PRODUCT_ID;
+
+            /* when */
+            /* then */
+            performWithAuth(delete(BASE_UTL + "/{productId}", productId), role)
+                    .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/product/src/test/java/com/nowayback/product/presentation/stock/StockControllerTest.java
+++ b/product/src/test/java/com/nowayback/product/presentation/stock/StockControllerTest.java
@@ -1,0 +1,176 @@
+package com.nowayback.product.presentation.stock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nowayback.common.security.annotation.UserRole;
+import com.nowayback.product.application.stock.StockService;
+import com.nowayback.product.application.stock.dto.StockResult;
+import com.nowayback.product.presentation.ControllerTest;
+import com.nowayback.product.presentation.stock.dto.request.DecreaseStockRequest;
+import com.nowayback.product.presentation.stock.dto.request.IncreaseStockRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static com.nowayback.product.fixture.StockFixture.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(StockController.class)
+@DisplayName("재고 컨트롤러 테스트")
+class StockControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private StockService stockService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final String BASE_URL = "/stocks";
+
+    @Nested
+    @DisplayName("재고 증가 API")
+    class IncreaseStock {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER"})
+        @DisplayName("유효한 요청이 들어오면 재고가 정상적으로 증가된다.")
+        void increaseStock_Success(UserRole role) throws Exception {
+            /* given */
+            IncreaseStockRequest request = VALID_INCREASE_STOCK_REQUEST;
+            StockResult result = STOCK_RESULT;
+
+            given(stockService.increaseStock(any())).willReturn(result);
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{productId}/increase", PRODUCT_UUID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.productId").value(PRODUCT_UUID.toString()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청이 들어오면 응답코드 400을 반환한다.")
+        void increaseStock_InvalidRequest_BadRequest() throws Exception {
+            /* given */
+            IncreaseStockRequest request = INVALID_INCREASE_STOCK_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{productId}/increase", PRODUCT_UUID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void increaseStock_UnauthenticatedUser_Unauthorized() throws Exception {
+            /* given */
+            IncreaseStockRequest request = VALID_INCREASE_STOCK_REQUEST;
+
+            /* when */
+            /* then */
+            mockMvc.perform(patch(BASE_URL + "/{productId}/increase", PRODUCT_UUID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void increaseStock_ForbiddenUser_Forbidden(UserRole role) throws Exception {
+            /* given */
+            IncreaseStockRequest request = VALID_INCREASE_STOCK_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{productId}/increase", PRODUCT_UUID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("재고 감소 API")
+    class DecreaseStock {
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"MASTER", "HUB_MANAGER"})
+        @DisplayName("유효한 요청이 들어오면 재고가 정상적으로 감소된다.")
+        void decreaseStock_Success(UserRole role) throws Exception {
+            /* given */
+            DecreaseStockRequest request = VALID_DECREASE_STOCK_REQUEST;
+            StockResult result = STOCK_RESULT;
+
+            given(stockService.decreaseStock(any())).willReturn(result);
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{productId}/decrease", PRODUCT_UUID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.productId").value(PRODUCT_UUID.toString()));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 요청이 들어오면 응답코드 400을 반환한다.")
+        void decreaseStock_InvalidRequest_BadRequest() throws Exception {
+            /* given */
+            DecreaseStockRequest request = INVALID_DECREASE_STOCK_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{productId}/decrease", PRODUCT_UUID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 요청하면 응답코드 401을 반환한다.")
+        void decreaseStock_UnauthenticatedUser_Unauthorized() throws Exception {
+            /* given */
+            DecreaseStockRequest request = VALID_DECREASE_STOCK_REQUEST;
+
+            /* when */
+            /* then */
+            mockMvc.perform(patch(BASE_URL + "/{productId}/decrease", PRODUCT_UUID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = UserRole.class, names = {"DELIVERY_MANAGER", "COMPANY_MANAGER"})
+        @DisplayName("권한이 없는 사용자가 요청하면 응답코드 403을 반환한다.")
+        void decreaseStock_ForbiddenUser_Forbidden(UserRole role) throws Exception {
+            /* given */
+            DecreaseStockRequest request = VALID_DECREASE_STOCK_REQUEST;
+
+            /* when */
+            /* then */
+            performWithAuth(patch(BASE_URL + "/{productId}/decrease", PRODUCT_UUID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+                    role)
+                    .andExpect(status().isForbidden());
+        }
+    }
+}


### PR DESCRIPTION
## 📒 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #51 

## 📒 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 상품 마이크로서비스 기본 설정
  - `docker-compose.local.yml`, `Dockerfile`, `application.yaml` (local, prod) 파일 작성
  - `build.gradle` 파일 수정
- 상품 도메인 작성
  - 상품 엔티티
    - `CompanyId`, `HubId`, `ProductInfo`로의 VO 분리
    - 상품 생성 시 각 VO에 대한 null 체크 수행
  - 상품 서비스
    - `createProduct` : 상품 생성 (-> 재고 생성)
    - `deleteProduct` : 상품 삭제 (-> 재고 삭제)
  - 상품 컨트롤러
    - 상품 생성 (`MASTER`, `HUB_MANAGER`만 가능)
    - 상품 삭제 (`MASTER`, `HUB_MANAGER`만 가능)

- 재고 도메인 작성
  - 재고 엔티티
    - `ProductId`, `Quantity`로의 VO 분리
      - `Quantity` VO로 수량 증가 및 감소 로직 위임
    - 재고 생성 시 `ProductId`의 null 체크 수행
    - 재고 생성 시 수량이 0인 `Quantity` 할당
    - 재고의 수량 변경 시 `Quantity`의 null 체크 수행
  - 재고 서비스
    - `createStock` : 상품 ID에 대한 재고 생성 (중복 체크 수행)
    - `getStock` : 상품 ID에 대한 재고 조회
    - `increaseStock` : 재고 수량 증가
    - `decreaseStock` : 재고 수량 감소
    - `deleteStock` : 상품 ID에 대한 재고 삭제
  - 재고 컨트롤러
    - 재고 수량 증가 (`MASTER`, `HUB_MANAGER`만 가능)
    - 재고 수량 감소 (`MASTER`, `HUB_MANAGER`만 가능)

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
상품 및 재고의 엔티티, 리포지토리, 서비스, 컨트롤러에 대한 테스트 코드 확인 부탁드립니다~ (모두 통과)

## 📒 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
로직이 의도대로 잘 작성되었는지 확인 부탁드립니다!
